### PR TITLE
Self-hosted map tiles with full bikeway rendering

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,5 +8,6 @@ export const GIRA_WS_URL = 'wss://c2g091p01.emel.pt/ws';
 export const GIRA_MAIS_API_URL = 'https://gira-mais.app/api';
 
 export const ROUTING_API_URL = 'https://routing.gira-mais.app';
+export const TILES_URL = 'https://tiles.gira-mais.app';
 // Area covered by the routing/geocoding server (minLon,minLat,maxLon,maxLat)
 export const ROUTING_BBOX = [-9.55, 38.55, -8.85, 38.95] as const;

--- a/src/lib/map-style.ts
+++ b/src/lib/map-style.ts
@@ -1,5 +1,6 @@
 // import oldStyle from '../../static/assets/old-style.json'
 import type { DataDrivenPropertyValueSpecification } from 'maplibre-gl';
+import { TILES_URL } from './constants';
 
 export function getMapStyle(style:'dark'|'light'): maplibregl.StyleSpecification {
 	const cLight = {
@@ -202,11 +203,15 @@ export function getMapStyle(style:'dark'|'light'): maplibregl.StyleSpecification
 		'sources': {
 			'openmaptiles': {
 				'type': 'vector',
-				'url': 'https://tiles2.intermodal.pt/data/v3.json',
+				'url': `${TILES_URL}/data/v3.json`,
+			},
+			'bikeways': {
+				'type': 'vector',
+				'url': `${TILES_URL}/data/bikeways.json`,
 			},
 		},
-		'sprite': 'https://tiles2.intermodal.pt/styles/iml/sprite',
-		'glyphs': 'https://tiles2.intermodal.pt/fonts/{fontstack}/{range}.pbf',
+		'sprite': `${TILES_URL}/styles/iml/sprite`,
+		'glyphs': `${TILES_URL}/fonts/{fontstack}/{range}.pbf`,
 		'layers': [
 			{
 				'id': 'background',
@@ -1663,16 +1668,11 @@ export function getMapStyle(style:'dark'|'light'): maplibregl.StyleSpecification
 			{
 				'id': 'path_cycleway_casing',
 				'type': 'line',
-				'source': 'openmaptiles',
-				'source-layer': 'transportation',
-				'minzoom': 14,
+				'source': 'bikeways',
+				'source-layer': 'bikeways',
+				'minzoom': 11,
 				'maxzoom': 24,
-				'filter': [
-					'all',
-					['==', ['geometry-type'], 'LineString'],
-					['match', ['get', 'class'], ['path', 'track'], true, false],
-					['==', ['get', 'subclass'], 'cycleway'],
-				],
+				'filter': ['match', ['get', 'kind'], ['cycleway', 'shared'], true, false],
 				'layout': {
 					'line-cap': 'round',
 					'line-join': 'round',
@@ -1684,28 +1684,25 @@ export function getMapStyle(style:'dark'|'light'): maplibregl.StyleSpecification
 						'interpolate',
 						['exponential', 1.2],
 						['zoom'],
+						11,
+						1.5,
 						14,
 						4,
 						20,
 						20,
 					],
 					'line-color': colors.cycleway.casing,
-					'line-opacity': ['interpolate', ['linear'], ['zoom'], 14, 0, 15, 1],
+					'line-opacity': ['interpolate', ['linear'], ['zoom'], 11, 0, 12, 1],
 				},
 			},
 			{
 				'id': 'path_cycleway',
 				'type': 'line',
-				'source': 'openmaptiles',
-				'source-layer': 'transportation',
-				'minzoom': 14,
+				'source': 'bikeways',
+				'source-layer': 'bikeways',
+				'minzoom': 11,
 				'maxzoom': 24,
-				'filter': [
-					'all',
-					['==', ['geometry-type'], 'LineString'],
-					['match', ['get', 'class'], ['path', 'track'], true, false],
-					['==', ['get', 'subclass'], 'cycleway'],
-				],
+				'filter': ['match', ['get', 'kind'], ['cycleway', 'shared'], true, false],
 				'layout': {
 					'line-cap': 'round',
 					'line-join': 'round',
@@ -1713,17 +1710,49 @@ export function getMapStyle(style:'dark'|'light'): maplibregl.StyleSpecification
 					'line-round-limit': 0,
 				},
 				'paint': {
-					'line-opacity': ['interpolate', ['linear'], ['zoom'], 14, 0, 15, 1],
+					'line-opacity': ['interpolate', ['linear'], ['zoom'], 11, 0, 12, 1],
 					'line-width': [
 						'interpolate',
 						['exponential', 1.2],
 						['zoom'],
+						11,
+						0.75,
 						14,
 						2,
 						20,
 						16,
 					],
 					'line-color': colors.cycleway.inner,
+				},
+			},
+			{
+				'id': 'bikeway_lane',
+				'type': 'line',
+				'source': 'bikeways',
+				'source-layer': 'bikeways',
+				'minzoom': 11,
+				'maxzoom': 24,
+				'filter': ['==', ['get', 'kind'], 'lane'],
+				'layout': {
+					'line-cap': 'butt',
+					'line-join': 'round',
+					'visibility': 'visible',
+				},
+				'paint': {
+					'line-opacity': ['interpolate', ['linear'], ['zoom'], 11, 0, 12, 1],
+					'line-width': [
+						'interpolate',
+						['exponential', 1.2],
+						['zoom'],
+						11,
+						0.6,
+						14,
+						1.5,
+						20,
+						10,
+					],
+					'line-color': colors.cycleway.inner,
+					'line-dasharray': [2, 1.5],
 				},
 			},
 			{


### PR DESCRIPTION
> [!NOTE]
> Stacked on #71 (branch includes its commits); retarget to `main` if #71 merges first, or merge after it.

## What

Moves the base map from `tiles2.intermodal.pt` to our own tile server at `https://tiles.gira-mais.app`, and fixes the map showing fewer bikeways than the routing service actually uses.

## Why

Routing (#71) and the map tiles are both built from OSM, but the standard OpenMapTiles schema drops the `cycleway`/`cycleway:left`/`cycleway:right` tags, so on-road cycle lanes — **~89 km in Lisbon alone, ~50% more than the dedicated cycleways the map showed** — were invisible no matter how the style was filtered. The OSRM bicycle profile weights those lanes favourably, so routes kept preferring bikeways the map didn't draw.

## Server

- Two tilesets from the same Geofabrik Portugal extract the routing data uses:
  - `/data/v3.json` — OpenMapTiles base map built with Planetiler (~400 MB)
  - `/data/bikeways.json` — 1.3 MB overlay with every way the bicycle profile treats as cycling infrastructure, classified `kind=cycleway|lane|shared`
- Fonts (Metropolis + Noto Sans) and the 2-icon sprite are self-hosted too; nothing references Intermodal anymore

## App

- `map-style.ts`: sources/glyphs/sprite point at `TILES_URL`; cycleway layers read the bikeways overlay; new dashed `bikeway_lane` layer for on-road lanes
- Bikeway layers start at zoom 11 (was 14), fading in at z11–12 with thinner widths, unchanged from z14 up

<img width="300" alt="map" src="https://github.com/user-attachments/assets/f3ee5f6c-be39-40e7-9f15-78b1df114253" />
<img width="300" alt="map with lower zoom" src="https://github.com/user-attachments/assets/0053aa20-9523-4f40-bebb-24d333cf3735" />

## Test plan
- [x] `bun run check`, eslint on touched files
- [x] Style validates against the MapLibre style spec
- [x] All public endpoints verified (TileJSON, tiles, fonts, sprite); decoded a live bikeways tile over Avenidas Novas — contains `cycleway` and `lane` features
- [x] Visual check of lane rendering at z11–16 (couldn't browser-test: preview needs re-auth)