### PR TITLE
Trip navigation view

### DIFF
--- a/src/lib/compass.ts
+++ b/src/lib/compass.ts
@@ -1,0 +1,78 @@
+import { writable } from 'svelte/store';
+import { shortestAngleDelta } from '$lib/marker-animation';
+
+/** Direction the top of the screen points, in degrees clockwise from north,
+ * from the device orientation sensors; null while unavailable or denied. */
+export const compassHeading = writable<number|null>(null);
+
+type DeviceOrientationEventStatic = typeof DeviceOrientationEvent & {
+	requestPermission?: () => Promise<'granted'|'denied'>;
+};
+type CompassEvent = DeviceOrientationEvent & { webkitCompassHeading?: number };
+
+// The sensors report at tens of hertz with sub-degree jitter; only meaningful
+// turns are published
+const MIN_INTERVAL_ms = 200;
+const MIN_CHANGE_deg = 2;
+let lastUpdate = 0;
+let lastValue: number|null = null;
+
+function publish(heading: number) {
+	const now = Date.now();
+	if (lastValue !== null) {
+		if (now - lastUpdate < MIN_INTERVAL_ms) return;
+		if (Math.abs(shortestAngleDelta(lastValue, heading)) < MIN_CHANGE_deg) return;
+	}
+	lastUpdate = now;
+	lastValue = heading;
+	compassHeading.set(heading);
+}
+
+// In landscape the screen's top is no longer the device's top, but it's still
+// what the user perceives as "forward"
+function screenAngle() {
+	return window.screen?.orientation?.angle ?? 0;
+}
+
+function onOrientation(e: CompassEvent) {
+	if (typeof e.webkitCompassHeading === 'number' && Number.isFinite(e.webkitCompassHeading)) {
+		// iOS: OS-provided tilt-compensated compass heading of the device top
+		publish((e.webkitCompassHeading + screenAngle()) % 360);
+	} else if (e.absolute && e.alpha !== null) {
+		// elsewhere alpha is the yaw relative to north when the reading is absolute
+		publish((360 - e.alpha + screenAngle()) % 360);
+	}
+}
+
+let started = false;
+
+/** Start listening to the device compass. On iOS the first call must come
+ * from a user gesture, since it prompts for motion permission; calling it
+ * repeatedly is safe and cheap. */
+export async function startCompass() {
+	if (started || typeof window === 'undefined') return;
+	const orientationEvent = window.DeviceOrientationEvent as DeviceOrientationEventStatic|undefined;
+	if (!orientationEvent) return;
+	const supportsAbsolute = 'ondeviceorientationabsolute' in window;
+	try {
+		if (typeof orientationEvent.requestPermission === 'function') {
+			if (await orientationEvent.requestPermission() !== 'granted') return;
+			window.addEventListener('deviceorientation', onOrientation);
+		} else if (supportsAbsolute) {
+			window.addEventListener('deviceorientationabsolute', onOrientation as EventListener);
+		} else {
+			// the handler still ignores non-absolute readings
+			window.addEventListener('deviceorientation', onOrientation);
+		}
+		started = true;
+	} catch {
+		// the permission request threw (e.g. called outside a user gesture) —
+		// a later call from an actual tap can still succeed
+	}
+}
+
+// Only iOS gates the sensor behind a permission prompt — everywhere else the
+// compass can start with the app
+if (typeof window !== 'undefined' && typeof (window.DeviceOrientationEvent as DeviceOrientationEventStatic|undefined)?.requestPermission !== 'function') {
+	startCompass();
+}

--- a/src/lib/components/Compass.svelte
+++ b/src/lib/components/Compass.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { startCompass } from '$lib/compass';
 	import { bearing, bearingNorth } from '$lib/location';
 	import { viewMode } from '$lib/map.svelte';
 	import { fade } from 'svelte/transition';
@@ -6,6 +7,7 @@
 	// In the heading-aligned navigation view the camera re-rotates on every
 	// frame, so pointing north requires leaving that view first
 	function reorient() {
+		startCompass();
 		if ($viewMode === 'heading') $viewMode = 'north';
 		else bearingNorth.set(true);
 	}

--- a/src/lib/components/Compass.svelte
+++ b/src/lib/components/Compass.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
 	import { bearing, bearingNorth } from '$lib/location';
+	import { viewMode } from '$lib/map.svelte';
 	import { fade } from 'svelte/transition';
+
+	// In the heading-aligned navigation view the camera re-rotates on every
+	// frame, so pointing north requires leaving that view first
+	function reorient() {
+		if ($viewMode === 'heading') $viewMode = 'north';
+		else bearingNorth.set(true);
+	}
 </script>
 
 {#if $bearing !== 0}
-	<button aria-label="Reorient Compass" onclick={() => bearingNorth.set(true)} transition:fade={{ duration: 150 }} class="bg-background dark:bg-background-secondary p-2 rounded-full grid grid-cols-1 grid-rows-1 w-12 h-12 active:bg-background-secondary dark:active:bg-background-tertiary" style:box-shadow="0px 0px 20px 0px var(--color-shadow)">
+	<button aria-label="Reorient Compass" onclick={reorient} transition:fade={{ duration: 150 }} class="bg-background dark:bg-background-secondary p-2 rounded-full grid grid-cols-1 grid-rows-1 w-12 h-12 active:bg-background-secondary dark:active:bg-background-tertiary" style:box-shadow="0px 0px 20px 0px var(--color-shadow)">
 		<svg class="w-full h-full" style:transform="rotate({-$bearing}deg)" width="30" height="90" viewBox="0 0 30 90" fill="none" xmlns="http://www.w3.org/2000/svg">
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M28.5166 52.6049C29.2024 50.5049 29.5452 47.7524 29.5452 45H0.45459C0.454585 47.7524 0.797443 50.5049 1.48317 52.6049L12.5167 86.3953C13.8881 90.5953 16.1117 90.5953 17.4831 86.3953L28.5166 52.6049Z" class="fill-background-tertiary dark:fill-label dark:opacity-50" />
 			<path d="M28.5166 37.3952L17.4831 3.60487C16.1117 -0.595175 13.8881 -0.595177 12.5167 3.60486L1.48317 37.3952C0.797454 39.4952 0.454595 42.2476 0.45459 45H29.5452C29.5452 42.2476 29.2024 39.4952 28.5166 37.3952Z" class="fill-primary" />

--- a/src/lib/components/Floating.svelte
+++ b/src/lib/components/Floating.svelte
@@ -28,17 +28,26 @@
 	let x = $state<{ left: number|undefined, right: number|undefined }>({ left: undefined, right: undefined });
 
 	let show = $state(true);
+	let showTimeout: ReturnType<typeof setTimeout>;
 	$effect(() => {
-		show = false;
-		x = { left, right };
-		if (y !== undefined) {
-			if (bottom) {
-				pos = Math.max((innerHeight - y) + offset, $safeInsets.bottom);
-			} else {
-				pos = Math.max(y + offset, $safeInsets.top);
-			}
-			setTimeout(() => show = true, 150);
+		// The right inset (notch side in landscape-secondary) is applied here;
+		// left-anchored floats already ride the trip HUD's width, which reserves
+		// the left inset itself
+		const next = { left, right: right === undefined ? undefined : right + $safeInsets.right };
+		const movedX = next.left !== x.left || next.right !== x.right;
+		if (movedX) x = next;
+		if (y === undefined) {
+			show = false;
+			return;
 		}
+		const nextPos = bottom ? Math.max((innerHeight - y) + offset, $safeInsets.bottom) : Math.max(y + offset, $safeInsets.top);
+		// Anchors get re-pushed without actually moving (a trip update re-reserving
+		// the same HUD height, an inset refetch) — blink only for a real move
+		if (!movedX && nextPos === pos && show) return;
+		pos = nextPos;
+		show = false;
+		clearTimeout(showTimeout);
+		showTimeout = setTimeout(() => show = true, 150);
 	});
 </script>
 

--- a/src/lib/components/LocationButton.svelte
+++ b/src/lib/components/LocationButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { startCompass } from '$lib/compass';
 	import { currentPos, watchPosition } from '$lib/location';
 	import { following, viewMode } from '$lib/map.svelte';
 	import { currentTrip } from '$lib/trip';
@@ -15,6 +16,9 @@
 
 <button class="bg-background dark:bg-background-secondary p-2 rounded-full grid grid-cols-1 grid-rows-1 w-12 h-12 active:bg-background dark:active:bg-background-tertiary transition-colors" style:box-shadow="0px 0px 20px 0px var(--color-shadow)"
 	onclick={() => {
+		// iOS only exposes the compass after a permission prompt triggered from a
+		// tap, and this button is the natural one
+		startCompass();
 		if (locationPermission) {
 			if (!$following) {
 				$following = true;

--- a/src/lib/components/LocationButton.svelte
+++ b/src/lib/components/LocationButton.svelte
@@ -46,7 +46,7 @@
 				<svg
 					xmlns="http://www.w3.org/2000/svg" class="text-primary" width="32" height="32" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
 					<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-					<path transition:draw={{ duration: 150 }} d="M12 18.5l7.5 3.5l-7.5 -18l-7.5 18l7.5 -3.5z" />
+					<path transition:draw={{ duration: 150 }} d="M12 16.5l7.5 3.5l-7.5 -18l-7.5 18l7.5 -3.5z" />
 				</svg>
 			</div>
 		{:else}

--- a/src/lib/components/LocationButton.svelte
+++ b/src/lib/components/LocationButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { currentPos, watchPosition } from '$lib/location';
-	import { following } from '$lib/map.svelte';
+	import { following, viewMode } from '$lib/map.svelte';
+	import { currentTrip } from '$lib/trip';
 	import { Capacitor } from '@capacitor/core';
 	import { Geolocation } from '@capacitor/geolocation';
 	import { draw } from 'svelte/transition';
@@ -15,8 +16,16 @@
 <button class="bg-background dark:bg-background-secondary p-2 rounded-full grid grid-cols-1 grid-rows-1 w-12 h-12 active:bg-background dark:active:bg-background-tertiary transition-colors" style:box-shadow="0px 0px 20px 0px var(--color-shadow)"
 	onclick={() => {
 		if (locationPermission) {
-			$following = !$following;
-			if ($following) watchPosition();
+			if (!$following) {
+				$following = true;
+				watchPosition();
+			} else if ($currentTrip !== null) {
+				// while riding, tapping again toggles between the heading-aligned
+				// navigation view and the north-oriented top-down view
+				$viewMode = $viewMode === 'heading' ? 'north' : 'heading';
+			} else {
+				$following = false;
+			}
 		} else {
 			if (Capacitor.getPlatform() !== 'web') {
 				Geolocation.requestPermissions().then(({ location }) => {
@@ -32,18 +41,28 @@
 		}
 	}} >
 	{#if locationPermission}
-		<div style="grid-row: 1;grid-column: 1;" >
-			<svg
-				xmlns="http://www.w3.org/2000/svg" class="transition-all {$currentPos ? '' : 'animate-[spin_3s_linear_infinite]'} {$following ? 'text-primary' : 'text-label'}" width="32" height="32" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-				<path transition:draw={{ duration: 150 }} stroke="none" d="M0 0h24v24H0z" fill="none"/>
-				<path transition:draw={{ duration: 150 }} class:animate-searching={!$currentPos} d="M12 12m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" />
-				<path transition:draw={{ duration: 150 }} d="M12 12m-8 0a8 8 0 1 0 16 0a8 8 0 1 0 -16 0" />
-				<path d="M12 4l0 -2" />
-				<path d="M12 20l0 2" />
-				<path d="M20 12h2" />
-				<path d="M4 12l-2 0" />
-			</svg>
-		</div>
+		{#if $following && $viewMode === 'heading'}
+			<div style="grid-row: 1;grid-column: 1;" >
+				<svg
+					xmlns="http://www.w3.org/2000/svg" class="text-primary" width="32" height="32" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+					<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+					<path transition:draw={{ duration: 150 }} d="M12 18.5l7.5 3.5l-7.5 -18l-7.5 18l7.5 -3.5z" />
+				</svg>
+			</div>
+		{:else}
+			<div style="grid-row: 1;grid-column: 1;" >
+				<svg
+					xmlns="http://www.w3.org/2000/svg" class="transition-all {$currentPos ? '' : 'animate-[spin_3s_linear_infinite]'} {$following ? 'text-primary' : 'text-label'}" width="32" height="32" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+					<path transition:draw={{ duration: 150 }} stroke="none" d="M0 0h24v24H0z" fill="none"/>
+					<path transition:draw={{ duration: 150 }} class:animate-searching={!$currentPos} d="M12 12m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" />
+					<path transition:draw={{ duration: 150 }} d="M12 12m-8 0a8 8 0 1 0 16 0a8 8 0 1 0 -16 0" />
+					<path d="M12 4l0 -2" />
+					<path d="M12 20l0 2" />
+					<path d="M20 12h2" />
+					<path d="M4 12l-2 0" />
+				</svg>
+			</div>
+		{/if}
 	{:else}
 		<div style="grid-row: 1;grid-column: 1;" >
 			<svg

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -3,6 +3,7 @@
 	import { bearing, bearingNorth, currentHeading, currentPos } from '$lib/location';
 	import { getMapStyle } from '$lib/map-style';
 	import { addLayers, following, loadImages, selectedStation, setSourceData, stations, viewMode } from '$lib/map.svelte';
+	import { appSettings } from '$lib/settings';
 	import { createMarkerAnimator, type MarkerState } from '$lib/marker-animation';
 	import { computeRoute, currentRoute, routeDestination, type PlannedRoute } from '$lib/routing';
 	import { clipRouteAtProjection, emptyRouteClippingState, projectPositionOntoRoute, remainingRoute, type RouteClippingState } from '$lib/route-clipping';
@@ -366,6 +367,10 @@
 	currentHeading.subscribe(heading => {
 		if (heading !== null) marker.setHeading(heading);
 	});
+
+	// Smoothing can be turned off from the development settings to compare the
+	// glide against the raw fix stream
+	appSettings.subscribe(settings => marker.setSmoothing(settings?.markerSmoothing ?? true));
 
 	function applyRouteData(route: PlannedRoute|null, pos = get(currentPos)) {
 		const src = map.getSource<maplibregl.GeoJSONSource>('route');

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -56,10 +56,29 @@
 	// half-way, leaving the pitch stuck in between — hold them off until it ends
 	let cameraTransition = false;
 	let cameraTransitionTimeout: ReturnType<typeof setTimeout>;
-	function beginCameraTransition(duration: number) {
+	// Each transition gets an id so a stale release (the moveend of a
+	// transition that was superseded mid-flight) can't cut a newer one short
+	let cameraTransitionId = 0;
+	function beginCameraTransition(duration?: number) {
 		cameraTransition = true;
 		clearTimeout(cameraTransitionTimeout);
-		cameraTransitionTimeout = setTimeout(() => cameraTransition = false, duration + 100);
+		const id = ++cameraTransitionId;
+		const release = () => {
+			if (id === cameraTransitionId) cameraTransition = false;
+		};
+		if (duration !== undefined) cameraTransitionTimeout = setTimeout(release, duration + 100);
+		return release;
+	}
+
+	// jumpTo stops the camera, and stopping the camera resets every gesture
+	// handler — a pan that has just touched down is wiped before its first
+	// move (the one that fires dragstart and breaks the follow), leaving the
+	// map immovable while the marker glides. Hold the per-frame follow off
+	// while a pointer is on the map or a gesture-driven animation (pinch,
+	// wheel zoom, double-tap) is still running
+	const pointersDown = new Set<number>;
+	function gestureInProgress() {
+		return pointersDown.size > 0 || map.isMoving();
 	}
 
 	// Glides the location marker between GPS fixes instead of teleporting it;
@@ -67,7 +86,7 @@
 	// re-centered on each raw fix, so the map travels as smoothly as the marker
 	const marker = createMarkerAnimator(state => {
 		renderUserMarker(state);
-		if (!mapLoaded || blurred || cameraTransition || !get(following)) return;
+		if (!mapLoaded || blurred || cameraTransition || !get(following) || gestureInProgress()) return;
 		if (get(viewMode) === 'heading') {
 			map.jumpTo({ center: [state.lng, state.lat], bearing: state.heading });
 		} else {
@@ -335,19 +354,24 @@
 	}
 
 	// Pulls the top-down view back onto the marker: the deliberate move made when
-	// the follow starts or the padded center shifts, not a per-fix correction
-	const RECENTER_ms = 800;
+	// the follow starts or the padded center shifts, not a per-fix correction.
+	// flyTo picks its duration from the distance (the first centering after
+	// launch crosses the whole city, a padding shift barely moves), so the
+	// hold-off is released by the movement ending rather than by a timer
 	function recenterNorthView() {
 		if (!mapLoaded || blurred || cameraTransition || !get(following) || get(viewMode) !== 'north') return;
 		const state = markerState();
 		if (!state) return;
-		beginCameraTransition(RECENTER_ms);
+		const release = beginCameraTransition();
 		map.flyTo({
 			center: [state.lng, state.lat],
 			padding: standardPadding(),
 			zoom: 16,
-			duration: RECENTER_ms,
 		});
+		// registered only after the flyTo call: its stop() synchronously fires
+		// the moveend of any ease it interrupts, which must not release this hold
+		if (map.isMoving()) map.once('moveend', release);
+		else release();
 	}
 
 	currentPos.subscribe((pos: Position|null) => {
@@ -531,6 +555,13 @@
 			attributionControl: false,
 		});
 		map.addControl(new maplibregl.AttributionControl, 'bottom-left');
+		// pointers can lift outside the map (or the app), so track the releases
+		// window-wide to never leave the follow stuck paused
+		const trackPointer = (e: PointerEvent) => pointersDown.add(e.pointerId);
+		const releasePointer = (e: PointerEvent) => pointersDown.delete(e.pointerId);
+		map.getCanvasContainer().addEventListener('pointerdown', trackPointer);
+		window.addEventListener('pointerup', releasePointer);
+		window.addEventListener('pointercancel', releasePointer);
 		map.once('load', async () => {
 			console.debug('Map loaded');
 			await loadImages(map);
@@ -543,6 +574,8 @@
 			addEventListeners(map);
 		});
 		return () => {
+			window.removeEventListener('pointerup', releasePointer);
+			window.removeEventListener('pointercancel', releasePointer);
 			marker.stop();
 			map.remove();
 		};

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { token } from '$lib/account';
-	import { bearing, bearingNorth, currentPos } from '$lib/location';
+	import { bearing, bearingNorth, currentHeading, currentPos } from '$lib/location';
 	import { getMapStyle } from '$lib/map-style';
-	import { addLayers, following, loadImages, selectedStation, setSourceData, stations } from '$lib/map.svelte';
+	import { addLayers, following, loadImages, selectedStation, setSourceData, stations, viewMode } from '$lib/map.svelte';
+	import { createMarkerAnimator, type MarkerState } from '$lib/marker-animation';
 	import { computeRoute, currentRoute, routeDestination, type PlannedRoute } from '$lib/routing';
 	import { clipRouteAtProjection, emptyRouteClippingState, projectPositionOntoRoute, remainingRoute, type RouteClippingState } from '$lib/route-clipping';
 	import { reverseGeocode } from '$lib/geocoding';
@@ -43,6 +44,118 @@
 
 	$effect(() => {
 		if ($bearingNorth) map.flyTo({ bearing: 0 });
+	});
+
+	const NAV_PITCH = 60;
+	const NAV_ZOOM = 17;
+	const NAV_TRANSITION_ms = 1400;
+
+	// While the camera eases into or out of the navigation view, the per-fix
+	// re-centering (and the per-frame follow) would cancel the animation
+	// half-way, leaving the pitch stuck in between — hold them off until it ends
+	let cameraTransition = false;
+	let cameraTransitionTimeout: ReturnType<typeof setTimeout>;
+	function beginCameraTransition(duration: number) {
+		cameraTransition = true;
+		clearTimeout(cameraTransitionTimeout);
+		cameraTransitionTimeout = setTimeout(() => cameraTransition = false, duration + 100);
+	}
+
+	// Glides the location marker between GPS fixes instead of teleporting it;
+	// in the navigation view the camera is pinned to the gliding marker
+	const marker = createMarkerAnimator(state => {
+		renderUserMarker(state);
+		if (mapLoaded && !cameraTransition && get(following) && get(viewMode) === 'heading') {
+			map.jumpTo({ center: [state.lng, state.lat], bearing: state.heading });
+		}
+	});
+
+	// The animator only starts tracking once the map has loaded, so fall back to
+	// the raw position for anything that needs a location before then
+	function markerState(): MarkerState|null {
+		const state = marker.displayed();
+		if (state) return state;
+		const pos = get(currentPos);
+		if (!pos) return null;
+		return { lng: pos.coords.longitude, lat: pos.coords.latitude, heading: get(currentHeading) ?? 0 };
+	}
+
+	function renderUserMarker(state: MarkerState|null = markerState()) {
+		if (!mapLoaded || !state) return;
+		const src = map.getSource<maplibregl.GeoJSONSource>('user-location');
+		if (src == null) return;
+		src.setData({
+			type: 'FeatureCollection',
+			features: [{
+				type: 'Feature',
+				properties: { nav: get(currentTrip) !== null, heading: state.heading },
+				geometry: {
+					type: 'Point',
+					coordinates: [state.lng, state.lat],
+				},
+			}],
+		});
+	}
+
+	// Extra top padding keeps the marker in the lower part of the view, showing
+	// the road ahead rather than what's behind
+	function navPadding() {
+		return {
+			top: topPadding + window.innerHeight * 0.35,
+			bottom: 0,
+			left: leftPadding,
+		};
+	}
+
+	function standardPadding() {
+		return { top: topPadding, bottom: Math.min(bottomPadding, window.innerHeight / 2), left: leftPadding };
+	}
+
+	function enterNavView() {
+		const state = markerState();
+		if (!state) return;
+		beginCameraTransition(NAV_TRANSITION_ms);
+		map.easeTo({
+			center: [state.lng, state.lat],
+			bearing: state.heading,
+			pitch: NAV_PITCH,
+			zoom: NAV_ZOOM,
+			padding: navPadding(),
+			duration: NAV_TRANSITION_ms,
+		});
+	}
+
+	function exitNavView() {
+		const state = markerState();
+		beginCameraTransition(1000);
+		if (get(following) && state) {
+			map.easeTo({
+				center: [state.lng, state.lat],
+				bearing: 0,
+				pitch: 0,
+				zoom: 16,
+				padding: standardPadding(),
+				duration: 1000,
+			});
+		} else {
+			map.easeTo({ bearing: 0, pitch: 0, duration: 1000 });
+		}
+	}
+
+	// Ease into the navigation view whenever it becomes active (trip start,
+	// re-following during a trip, toggling back from the north view)
+	let navWasActive = false;
+	$effect(() => {
+		const active = mapLoaded && !blurred && $following && $viewMode === 'heading' && $currentPos !== null;
+		if (active && !navWasActive) enterNavView();
+		navWasActive = active;
+	});
+
+	let lastViewMode = get(viewMode);
+	viewMode.subscribe(mode => {
+		if (mode === lastViewMode) return;
+		lastViewMode = mode;
+		if (mode === 'north' && mapLoaded) exitNavView();
 	});
 
 	// MapLibre recognizes the taps of one-finger zoom gestures (double-tap and
@@ -145,10 +258,23 @@
 			}, PIN_DROP_DELAY_ms);
 		});
 		map.on('dblclick', cancelPendingPinDrop);
-		map.on('zoomstart', cancelPendingPinDrop);
 		map.on('dragstart', cancelPendingPinDrop);
-		map.on('rotatestart', cancelPendingPinDrop);
-		map.on('pitchstart', cancelPendingPinDrop);
+		// The navigation view moves the camera programmatically all the time, so
+		// only user gestures (which carry the original DOM event) may cancel a
+		// pending pin drop
+		map.on('zoomstart', e => {
+			if (e.originalEvent) cancelPendingPinDrop();
+		});
+		map.on('pitchstart', e => {
+			if (e.originalEvent) cancelPendingPinDrop();
+		});
+		map.on('rotatestart', e => {
+			if (!e.originalEvent) return;
+			cancelPendingPinDrop();
+			// Manually rotating the map takes over from the heading-aligned camera,
+			// like dragging takes over from the centering
+			if (get(viewMode) === 'heading') following.set(false);
+		});
 		map.on('rotate', () => {
 			bearing.set(map.getBearing());
 			bearingNorth.set(false);
@@ -156,9 +282,10 @@
 	}
 
 	function centerMap(pos: Position) {
+		if (cameraTransition) return;
 		map.flyTo({
 			center: [pos.coords.longitude, pos.coords.latitude],
-			padding: { top: topPadding, bottom: Math.min(bottomPadding, window.innerHeight / 2), left: leftPadding },
+			padding: standardPadding(),
 			zoom: 16,
 		});
 	}
@@ -166,27 +293,12 @@
 	currentPos.subscribe((pos: Position|null) => {
 		if (!mapLoaded) return;
 		if (pos && pos.coords) {
-			if ($following && !blurred) centerMap(pos);
-			const src = map.getSource<maplibregl.GeoJSONSource>('user-location');
-			const data:GeoJSON = {
-				'type': 'FeatureCollection',
-				'features': [{
-					type: 'Feature',
-					properties: {},
-					geometry: {
-						type: 'Point',
-						coordinates: [pos.coords.longitude, pos.coords.latitude],
-					},
-				}],
-			};
-			if (src != null) {
-				src.setData(data);
-			} else {
-				map.addSource('user-location', {
-					'type': 'geojson',
-					'data': data,
-				});
-			}
+			if ($following && !blurred && get(viewMode) === 'north') centerMap(pos);
+			marker.setTarget({
+				lng: pos.coords.longitude,
+				lat: pos.coords.latitude,
+				heading: get(currentHeading),
+			});
 		}
 		applyRouteData(get(currentRoute), pos);
 	});
@@ -356,10 +468,12 @@
 			mapLoaded = true;
 			setSourceData(map);
 			addLayers(map);
+			renderUserMarker();
 			applyRouteData(get(currentRoute));
 			addEventListeners(map);
 		});
 		return () => {
+			marker.stop();
 			map.remove();
 		};
 	});
@@ -371,6 +485,7 @@
 				loadImages(map);
 				setSourceData(map);
 				addLayers(map);
+				renderUserMarker();
 				applyRouteData(get(currentRoute));
 				console.debug(map, map.getStyle(), map.getSource('points'));
 			});
@@ -378,7 +493,21 @@
 		}
 	});
 
+	let wasOnTrip = get(currentTrip) !== null;
 	currentTrip.subscribe(trip => {
+		const onTrip = trip !== null;
+		if (onTrip !== wasOnTrip) {
+			wasOnTrip = onTrip;
+			if (onTrip) {
+				// starting a trip pulls the camera into the navigation view
+				viewMode.set('heading');
+				following.set(true);
+			} else {
+				viewMode.set('north');
+			}
+			// swap the location marker between the dot and the heading arrow
+			renderUserMarker();
+		}
 		if (mapLoaded) {
 			map.setLayoutProperty('points', 'visibility', trip ? 'none' : 'visible');
 			map.setLayoutProperty('docks', 'visibility', trip ? 'visible' : 'none');
@@ -395,7 +524,7 @@
 	});
 
 	$effect(() => {
-		if ($following && !blurred && $currentPos && topPadding !== null && bottomPadding !== null && leftPadding !== null) centerMap($currentPos);
+		if ($following && !blurred && $currentPos && $viewMode === 'north' && topPadding !== null && bottomPadding !== null && leftPadding !== null) centerMap($currentPos);
 	});
 
 	$effect(() => {

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -243,6 +243,57 @@
 		}
 	}
 
+	// Sets a spot as the routing destination, deferred past the double-tap
+	// window and cancelled by zoom gestures
+	function schedulePinDrop(lngLat: { lat: number, lng: number }) {
+		cancelPendingPinDrop();
+		const destination = { type: 'location' as const, lat: lngLat.lat, lng: lngLat.lng };
+		// Compute the route and name right away so both are usually ready when
+		// the wait ends
+		const pos = get(currentPos);
+		let prefetchedRoute: PlannedRoute|null = null;
+		if (pos) {
+			computeRoute({ lat: pos.coords.latitude, lng: pos.coords.longitude }, destination, get(currentTrip) !== null)
+				.then(route => prefetchedRoute = route)
+				.catch(() => {}); // if it failed, the recompute below will retry and report
+		}
+		const geocoded = reverseGeocode(destination);
+		pendingPinDrop = setTimeout(() => {
+			pendingPinDrop = null;
+			// Publishing a route for this destination first makes the destination
+			// subscription in routing.ts skip its recompute; if the prefetch isn't
+			// done yet, the normal recompute takes over
+			if (prefetchedRoute) currentRoute.set(prefetchedRoute);
+			routeDestination.set(destination);
+			geocoded.then(name => {
+				const current = get(routeDestination);
+				if (current && current.lat === destination.lat && current.lng === destination.lng) {
+					// The generic fallback is only shown once the lookup concluded
+					// without a name — not while it's still pending
+					routeDestination.set({ ...destination, name: name ?? get(t)('selected_location') });
+				}
+			});
+		}, PIN_DROP_DELAY_ms);
+	}
+
+	// While riding, a stray tap on the map must not re-route — changing the
+	// destination takes a deliberate hold instead. Detected from the pointer
+	// tracking rather than from clicks, because mobile webviews don't reliably
+	// emit a click for a long press
+	const TRIP_PIN_HOLD_ms = 400;
+	const TRIP_PIN_HOLD_TOLERANCE_px = 10;
+	let press: { id: number, x: number, y: number, time: number }|null = null;
+
+	function tripHoldPinDrop(e: PointerEvent) {
+		if (!mapLoaded || get(currentTrip) === null) return;
+		if (get(selectedStation) != null) return; // the tap closes the menu instead
+		const rect = map.getCanvasContainer().getBoundingClientRect();
+		const point: [number, number] = [e.clientX - rect.left, e.clientY - rect.top];
+		// releases over a dock open its menu through the regular click path
+		if (map.queryRenderedFeatures(point, { layers: ['points', 'docks'] }).length > 0) return;
+		schedulePinDrop(map.unproject(point));
+	}
+
 	function addEventListeners(map: maplibregl.Map) {
 		async function onStationClick(e: maplibregl.MapLayerMouseEvent) {
 			if (e.features === undefined) return;
@@ -296,36 +347,10 @@
 				selectedStation.set(null);
 				return;
 			}
-			// Tapping an empty spot on the map sets it as the routing destination,
-			// deferred past the double-tap window and cancelled by zoom gestures
-			cancelPendingPinDrop();
-			const destination = { type: 'location' as const, lat: e.lngLat.lat, lng: e.lngLat.lng };
-			// Compute the route and name right away so both are usually ready when
-			// the wait ends
-			const pos = get(currentPos);
-			let prefetchedRoute: PlannedRoute|null = null;
-			if (pos) {
-				computeRoute({ lat: pos.coords.latitude, lng: pos.coords.longitude }, destination, get(currentTrip) !== null)
-					.then(route => prefetchedRoute = route)
-					.catch(() => {}); // if it failed, the recompute below will retry and report
-			}
-			const geocoded = reverseGeocode(destination);
-			pendingPinDrop = setTimeout(() => {
-				pendingPinDrop = null;
-				// Publishing a route for this destination first makes the destination
-				// subscription in routing.ts skip its recompute; if the prefetch isn't
-				// done yet, the normal recompute takes over
-				if (prefetchedRoute) currentRoute.set(prefetchedRoute);
-				routeDestination.set(destination);
-				geocoded.then(name => {
-					const current = get(routeDestination);
-					if (current && current.lat === destination.lat && current.lng === destination.lng) {
-						// The generic fallback is only shown once the lookup concluded
-						// without a name — not while it's still pending
-						routeDestination.set({ ...destination, name: name ?? get(t)('selected_location') });
-					}
-				});
-			}, PIN_DROP_DELAY_ms);
+			// While riding, quick taps are too easy to land by accident —
+			// re-routing takes the deliberate hold handled by the pointer tracking
+			if (get(currentTrip) !== null) return;
+			schedulePinDrop(e.lngLat);
 		});
 		map.on('dblclick', cancelPendingPinDrop);
 		map.on('dragstart', cancelPendingPinDrop);
@@ -557,8 +582,19 @@
 		map.addControl(new maplibregl.AttributionControl, 'bottom-left');
 		// pointers can lift outside the map (or the app), so track the releases
 		// window-wide to never leave the follow stuck paused
-		const trackPointer = (e: PointerEvent) => pointersDown.add(e.pointerId);
-		const releasePointer = (e: PointerEvent) => pointersDown.delete(e.pointerId);
+		const trackPointer = (e: PointerEvent) => {
+			// a hold only counts while it's the lone pointer from start to finish
+			press = pointersDown.size === 0 ? { id: e.pointerId, x: e.clientX, y: e.clientY, time: performance.now() } : null;
+			pointersDown.add(e.pointerId);
+		};
+		const releasePointer = (e: PointerEvent) => {
+			pointersDown.delete(e.pointerId);
+			if (!press || press.id !== e.pointerId) return;
+			const held = performance.now() - press.time;
+			const moved = Math.hypot(e.clientX - press.x, e.clientY - press.y);
+			press = null;
+			if (e.type === 'pointerup' && held >= TRIP_PIN_HOLD_ms && moved <= TRIP_PIN_HOLD_TOLERANCE_px) tripHoldPinDrop(e);
+		};
 		map.getCanvasContainer().addEventListener('pointerdown', trackPointer);
 		window.addEventListener('pointerup', releasePointer);
 		window.addEventListener('pointercancel', releasePointer);

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -62,11 +62,15 @@
 	}
 
 	// Glides the location marker between GPS fixes instead of teleporting it;
-	// in the navigation view the camera is pinned to the gliding marker
+	// while following, the camera is pinned to the gliding marker rather than
+	// re-centered on each raw fix, so the map travels as smoothly as the marker
 	const marker = createMarkerAnimator(state => {
 		renderUserMarker(state);
-		if (mapLoaded && !cameraTransition && get(following) && get(viewMode) === 'heading') {
+		if (!mapLoaded || blurred || cameraTransition || !get(following)) return;
+		if (get(viewMode) === 'heading') {
 			map.jumpTo({ center: [state.lng, state.lat], bearing: state.heading });
+		} else {
+			map.jumpTo({ center: [state.lng, state.lat] });
 		}
 	});
 
@@ -172,10 +176,20 @@
 		});
 	}
 
+	// Both follows reuse the padding left behind by their last camera move, so a
+	// layout change silently shifts the padded center — re-apply it. Only the
+	// top-down view is padded at the bottom (the station menu)
 	$effect(() => {
 		void topPadding;
 		void leftPadding;
 		realignNavCamera();
+	});
+
+	$effect(() => {
+		void topPadding;
+		void bottomPadding;
+		void leftPadding;
+		recenterNorthView();
 	});
 
 	// Ease into the navigation view whenever it becomes active (trip start,
@@ -319,19 +333,25 @@
 		map.on('resize', realignNavCamera);
 	}
 
-	function centerMap(pos: Position) {
-		if (cameraTransition) return;
+	// Pulls the top-down view back onto the marker: the deliberate move made when
+	// the follow starts or the padded center shifts, not a per-fix correction
+	const RECENTER_ms = 800;
+	function recenterNorthView() {
+		if (!mapLoaded || blurred || cameraTransition || !get(following) || get(viewMode) !== 'north') return;
+		const state = markerState();
+		if (!state) return;
+		beginCameraTransition(RECENTER_ms);
 		map.flyTo({
-			center: [pos.coords.longitude, pos.coords.latitude],
+			center: [state.lng, state.lat],
 			padding: standardPadding(),
 			zoom: 16,
+			duration: RECENTER_ms,
 		});
 	}
 
 	currentPos.subscribe((pos: Position|null) => {
 		if (!mapLoaded) return;
 		if (pos && pos.coords) {
-			if ($following && !blurred && get(viewMode) === 'north') centerMap(pos);
 			marker.setTarget({
 				lng: pos.coords.longitude,
 				lat: pos.coords.latitude,
@@ -573,8 +593,13 @@
 		}
 	});
 
+	// Like the navigation view, the top-down follow centers once when it becomes
+	// active; in between, the per-frame follow keeps the camera on the marker
+	let northWasActive = false;
 	$effect(() => {
-		if ($following && !blurred && $currentPos && $viewMode === 'north' && topPadding !== null && bottomPadding !== null && leftPadding !== null) centerMap($currentPos);
+		const active = mapLoaded && !blurred && $following && $viewMode === 'north' && $currentPos !== null;
+		if (active && !northWasActive) recenterNorthView();
+		northWasActive = active;
 	});
 
 	$effect(() => {

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -313,6 +313,12 @@
 		applyRouteData(get(currentRoute), pos);
 	});
 
+	// Compass-driven heading changes arrive between GPS fixes (e.g. turning on
+	// the spot) — rotate the marker without disturbing the position glide
+	currentHeading.subscribe(heading => {
+		if (heading !== null) marker.setHeading(heading);
+	});
+
 	function applyRouteData(route: PlannedRoute|null, pos = get(currentPos)) {
 		const src = map.getSource<maplibregl.GeoJSONSource>('route');
 		const destSrc = map.getSource<maplibregl.GeoJSONSource>('route-destination');

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -46,7 +46,7 @@
 		if ($bearingNorth) map.flyTo({ bearing: 0 });
 	});
 
-	const NAV_PITCH = 60;
+	const NAV_PITCH = 50;
 	const NAV_ZOOM = 17;
 	const NAV_TRANSITION_ms = 1400;
 
@@ -511,6 +511,10 @@
 		if (mapLoaded) {
 			map.setLayoutProperty('points', 'visibility', trip ? 'none' : 'visible');
 			map.setLayoutProperty('docks', 'visibility', trip ? 'visible' : 'none');
+			// while riding, the route has to stay legible at a glance, so thicken it
+			map.setPaintProperty('route-outline', 'line-width', trip ? 12 : 9);
+			map.setPaintProperty('route-bike', 'line-width', trip ? 8 : 5);
+			map.setPaintProperty('route-foot', 'line-width', trip ? 8 : 5);
 		}
 	});
 

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -142,6 +142,15 @@
 		}
 	}
 
+	// The chevron lies flat on the map, so tilting foreshortens it — it's drawn
+	// big enough for the tilted view and scaled down as the map flattens out,
+	// where the full size would look oversized. The dot is unaffected
+	function updateMarkerScale() {
+		if (!mapLoaded || map.getLayer('user-location') == null) return;
+		const t = Math.min(map.getPitch() / NAV_PITCH, 1);
+		map.setLayoutProperty('user-location', 'icon-size', ['case', ['to-boolean', ['get', 'nav']], 0.8 + 0.2 * t, 1]);
+	}
+
 	// Ease into the navigation view whenever it becomes active (trip start,
 	// re-following during a trip, toggling back from the north view)
 	let navWasActive = false;
@@ -279,6 +288,7 @@
 			bearing.set(map.getBearing());
 			bearingNorth.set(false);
 		});
+		map.on('pitch', updateMarkerScale);
 	}
 
 	function centerMap(pos: Position) {
@@ -469,6 +479,7 @@
 			setSourceData(map);
 			addLayers(map);
 			renderUserMarker();
+			updateMarkerScale();
 			applyRouteData(get(currentRoute));
 			addEventListeners(map);
 		});
@@ -486,6 +497,7 @@
 				setSourceData(map);
 				addLayers(map);
 				renderUserMarker();
+				updateMarkerScale();
 				applyRouteData(get(currentRoute));
 				console.debug(map, map.getStyle(), map.getSource('points'));
 			});

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -151,6 +151,33 @@
 		map.setLayoutProperty('user-location', 'icon-size', ['case', ['to-boolean', ['get', 'nav']], 0.8 + 0.2 * t, 1]);
 	}
 
+	// The per-frame follow reuses the padding left behind by enterNavView, so
+	// when the viewport or the HUD layout changes (e.g. rotating the device)
+	// the padded center silently moves — re-apply it with the fresh layout
+	function realignNavCamera() {
+		if (!mapLoaded || blurred || !get(following) || get(viewMode) !== 'heading') return;
+		if (cameraTransition) {
+			// still easing into the view — restart the transition with the new layout
+			enterNavView();
+			return;
+		}
+		const state = markerState();
+		if (!state) return;
+		beginCameraTransition(600);
+		map.easeTo({
+			center: [state.lng, state.lat],
+			bearing: state.heading,
+			padding: navPadding(),
+			duration: 600,
+		});
+	}
+
+	$effect(() => {
+		void topPadding;
+		void leftPadding;
+		realignNavCamera();
+	});
+
 	// Ease into the navigation view whenever it becomes active (trip start,
 	// re-following during a trip, toggling back from the north view)
 	let navWasActive = false;
@@ -289,6 +316,7 @@
 			bearingNorth.set(false);
 		});
 		map.on('pitch', updateMarkerScale);
+		map.on('resize', realignNavCamera);
 	}
 
 	function centerMap(pos: Position) {

--- a/src/lib/components/TripStatus.svelte
+++ b/src/lib/components/TripStatus.svelte
@@ -56,8 +56,8 @@
 		inter = setInterval(() => seconds++, 1000);
 		$following = true;
 		KeepAwake.keepAwake();
-		ScreenOrientation.orientation().then(o => portrait = o.type === 'portrait-primary');
-		ScreenOrientation.addListener('screenOrientationChange', o => portrait = o.type === 'portrait-primary');
+		ScreenOrientation.orientation().then(o => portrait = o.type.startsWith('portrait'));
+		ScreenOrientation.addListener('screenOrientationChange', o => portrait = o.type.startsWith('portrait'));
 		return () => {
 			clearInterval(inter);
 			KeepAwake.allowSleep();

--- a/src/lib/components/settings/Settings.svelte
+++ b/src/lib/components/settings/Settings.svelte
@@ -109,6 +109,13 @@
 						</div>
 						<Toggle bind:checked={$appSettings.mockUnlock} />
 					</div>
+					<div class="flex bg-background rounded-2xl py-4 px-5 gap-5 text-info justify-between items-center dark:bg-background-secondary" style:box-shadow="0px 0px 12px 0px var(--color-shadow)">
+						<div class="grow">
+							<div class="font-semibold leading-tight mb-1">{$t('marker_smoothing_setting_label')}</div>
+							<div class="text-xs font-medium leading-[1.1] text-label">{$t('marker_smoothing_setting_description')}</div>
+						</div>
+						<Toggle bind:checked={$appSettings.markerSmoothing} />
+					</div>
 				</div>
 			</div>
 		{/if}

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -2,11 +2,42 @@ import type { Position } from '@capacitor/geolocation';
 import { get } from 'svelte/store';
 import { currentPos, setDebugPosition } from '$lib/location';
 import { following } from '$lib/map.svelte';
-import { DEBUG_START_POSITION, toggleDebugTrip } from '$lib/trip';
+import { appSettings } from '$lib/settings';
+import { shortestAngleDelta } from '$lib/marker-animation';
+import { currentTrip, DEBUG_START_POSITION, toggleDebugTrip } from '$lib/trip';
 
-export const DEBUG_WALK_SPEED_MPS = 120;
+/** Riding a Gira, ~18 km/h. */
+export const DEBUG_BIKE_SPEED_MPS = 5;
+/** Walking to the station, ~5 km/h. */
+export const DEBUG_WALK_SPEED_MPS = 1.4;
+/** Holding shift covers ground quickly when the destination is far away. */
+const FAST_TRAVEL_FACTOR = 6;
+
 const EARTH_RADIUS_M = 6_371_000;
 const MOVEMENT_KEYS = new Set(['w', 'a', 's', 'd']);
+
+// A receiver reports roughly once a second, never quite on time, and loses the
+// odd fix under tree cover or between buildings
+const FIX_INTERVAL_ms = 1000;
+const FIX_JITTER_ms = 200;
+const FIX_DROP_CHANCE = 0.06;
+
+// Horizontal error wanders instead of being redrawn independently per fix, so
+// it is modelled as a slowly decaying random walk — that wander is what makes a
+// parked marker creep around. Multipath off a building throws a single fix much
+// further out
+const NOISE_SIGMA_m = 4;
+const NOISE_HALFLIFE_ms = 8000;
+const GLITCH_CHANCE = 0.03;
+const GLITCH_SIGMA_m = 20;
+
+// Neither the rider nor the reported course changes instantly
+const SPEED_HALFLIFE_ms = 800;
+const TURN_RATE_dps = 90;
+const SPEED_NOISE_mps = 0.3;
+const HEADING_NOISE_deg = 4;
+/** Below this a receiver stops reporting a usable course. */
+const COURSE_MIN_SPEED_mps = 0.8;
 
 export function moveCoordinates(lat: number, lng: number, east: number, north: number, distanceM: number) {
 	const length = Math.hypot(east, north);
@@ -18,49 +49,121 @@ export function moveCoordinates(lat: number, lng: number, east: number, north: n
 	return { lat: nextLat, lng: nextLng };
 }
 
+/** Standard normal sample (Box-Muller). */
+function gaussian() {
+	return Math.sqrt(-2 * Math.log(1 - Math.random())) * Math.cos(2 * Math.PI * Math.random());
+}
+
+/** Fraction of a value left after `elapsed`, decaying by half every `halflife`. */
+function decayed(halflife: number, elapsed: number) {
+	return Math.pow(0.5, elapsed / halflife);
+}
+
 function isEditableTarget(target: EventTarget | null) {
 	if (!(target instanceof HTMLElement)) return false;
 	return target.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'].includes(target.tagName);
 }
 
-function debugPosition(lat: number, lng: number, heading: number, timestamp: number): Position {
+function debugPosition(lat: number, lng: number, heading: number|null, speed: number, accuracy: number): Position {
 	return {
 		coords: {
 			latitude: lat,
 			longitude: lng,
-			accuracy: 1,
+			accuracy,
 			altitude: null,
 			altitudeAccuracy: null,
 			heading,
-			speed: DEBUG_WALK_SPEED_MPS,
+			speed,
 		},
-		timestamp,
+		timestamp: Date.now(),
 	};
 }
 
 export function startDebugControls() {
 	if (!import.meta.env.DEV || typeof window === 'undefined') return () => undefined;
 	const held = new Set<string>;
+	let fastTravel = false;
 	let frame: number | null = null;
 	let lastTime: number | null = null;
+
+	// The true position the rider is at, kept apart from what gets published:
+	// feeding the noisy fixes back in would let the error random-walk away
+	let truth: { lat: number, lng: number } = { ...DEBUG_START_POSITION };
+	let speed = 0;
+	let heading = 0;
+	let noiseEast = 0;
+	let noiseNorth = 0;
+	let fixTimeout: ReturnType<typeof setTimeout> | null = null;
+	let lastFixTime = 0;
+
+	const cruiseSpeed = () => (get(currentTrip) !== null ? DEBUG_BIKE_SPEED_MPS : DEBUG_WALK_SPEED_MPS) *
+		(fastTravel ? FAST_TRAVEL_FACTOR : 1);
+
+	const publishFix = () => {
+		const now = performance.now();
+		const elapsed = lastFixTime === 0 ? FIX_INTERVAL_ms : now - lastFixTime;
+		lastFixTime = now;
+
+		const decay = decayed(NOISE_HALFLIFE_ms, elapsed);
+		// Scaled so the walk settles at a standard deviation of NOISE_SIGMA_m
+		const spread = NOISE_SIGMA_m * Math.sqrt(1 - decay * decay);
+		noiseEast = noiseEast * decay + gaussian() * spread;
+		noiseNorth = noiseNorth * decay + gaussian() * spread;
+
+		const glitch = Math.random() < GLITCH_CHANCE;
+		const east = noiseEast + (glitch ? gaussian() * GLITCH_SIGMA_m : 0);
+		const north = noiseNorth + (glitch ? gaussian() * GLITCH_SIGMA_m : 0);
+		const offset = moveCoordinates(truth.lat, truth.lng, east, north, Math.hypot(east, north));
+
+		const reportedSpeed = Math.max(0, speed + gaussian() * SPEED_NOISE_mps);
+		const reportedHeading = speed >= COURSE_MIN_SPEED_mps ?
+			(heading + gaussian() * HEADING_NOISE_deg + 360) % 360 :
+			null;
+		const accuracy = Math.min(40, 4 + Math.hypot(east, north) * 0.8 + Math.abs(gaussian()) * 2);
+		setDebugPosition(debugPosition(offset.lat, offset.lng, reportedHeading, reportedSpeed, accuracy));
+	};
+
+	const scheduleFix = () => {
+		fixTimeout = setTimeout(() => {
+			// A dropped fix leaves a gap of roughly two intervals, like losing the
+			// sky for a moment
+			if (Math.random() >= FIX_DROP_CHANCE) publishFix();
+			scheduleFix();
+		}, FIX_INTERVAL_ms + (Math.random() * 2 - 1) * FIX_JITTER_ms);
+	};
+
+	const startFixes = () => {
+		if (fixTimeout !== null) return;
+		const position = get(currentPos);
+		truth = position ?
+			{ lat: position.coords.latitude, lng: position.coords.longitude } :
+			{ ...DEBUG_START_POSITION };
+		scheduleFix();
+	};
 
 	const step = (time: number) => {
 		frame = null;
 		const east = Number(held.has('d')) - Number(held.has('a'));
 		const north = Number(held.has('w')) - Number(held.has('s'));
-		if (east === 0 && north === 0) {
+		const elapsedSeconds = lastTime === null ? 0 : Math.min((time - lastTime) / 1000, 0.1);
+		lastTime = time;
+
+		// Ease onto and off the pedals, and lean into turns rather than pivoting
+		const target = east === 0 && north === 0 ? 0 : cruiseSpeed();
+		speed += (target - speed) * (1 - decayed(SPEED_HALFLIFE_ms, elapsedSeconds * 1000));
+		if (east !== 0 || north !== 0) {
+			const desired = (Math.atan2(east, north) * 180 / Math.PI + 360) % 360;
+			const turn = shortestAngleDelta(heading, desired);
+			heading = (heading + Math.sign(turn) * Math.min(Math.abs(turn), TURN_RATE_dps * elapsedSeconds) + 360) % 360;
+		}
+		truth = moveCoordinates(truth.lat, truth.lng, Math.sin(heading * Math.PI / 180), Math.cos(heading * Math.PI / 180), speed * elapsedSeconds);
+
+		// Coasting to a stop still moves, so keep stepping until it is negligible
+		if (target === 0 && speed < 0.05) {
+			speed = 0;
 			lastTime = null;
 			return;
 		}
-		const position = get(currentPos);
-		const lat = position?.coords.latitude ?? DEBUG_START_POSITION.lat;
-		const lng = position?.coords.longitude ?? DEBUG_START_POSITION.lng;
-		const elapsedSeconds = lastTime === null ? 0 : Math.min((time - lastTime) / 1000, 0.1);
-		lastTime = time;
-		const moved = moveCoordinates(lat, lng, east, north, DEBUG_WALK_SPEED_MPS * elapsedSeconds);
-		const heading = (Math.atan2(east, north) * 180 / Math.PI + 360) % 360;
-		setDebugPosition(debugPosition(moved.lat, moved.lng, heading, Date.now()));
-		following.set(true);
 		frame = requestAnimationFrame(step);
 	};
 
@@ -69,21 +172,32 @@ export function startDebugControls() {
 	};
 	const clearMovement = () => {
 		held.clear();
-		lastTime = null;
-		if (frame !== null) cancelAnimationFrame(frame);
-		frame = null;
+		fastTravel = false;
 	};
 	const keydown = (event: KeyboardEvent) => {
 		if (event.ctrlKey || event.altKey || event.metaKey || isEditableTarget(event.target)) return;
 		const key = event.key.toLowerCase();
+		fastTravel = event.shiftKey;
 		if (MOVEMENT_KEYS.has(key)) {
+			if (held.size === 0) following.set(true);
 			held.add(key);
+			startFixes();
 			startFrame();
 		} else if (key === 't' && !event.repeat) {
-			toggleDebugTrip();
+			if (toggleDebugTrip()) startFixes();
+		} else if (key === 'm' && !event.repeat) {
+			// The same switch as the development setting, for quick A/B comparisons
+			const settings = get(appSettings);
+			if (!settings) return;
+			const enabled = !settings.markerSmoothing;
+			appSettings.set({ ...settings, markerSmoothing: enabled });
+			console.info(`Marker smoothing ${enabled ? 'on' : 'off — raw fixes'}`);
 		}
 	};
-	const keyup = (event: KeyboardEvent) => held.delete(event.key.toLowerCase());
+	const keyup = (event: KeyboardEvent) => {
+		fastTravel = event.shiftKey;
+		held.delete(event.key.toLowerCase());
+	};
 	const visibilitychange = () => {
 		if (document.hidden) clearMovement();
 	};
@@ -94,6 +208,10 @@ export function startDebugControls() {
 	document.addEventListener('visibilitychange', visibilitychange);
 	return () => {
 		clearMovement();
+		if (frame !== null) cancelAnimationFrame(frame);
+		frame = null;
+		if (fixTimeout !== null) clearTimeout(fixTimeout);
+		fixTimeout = null;
 		window.removeEventListener('keydown', keydown);
 		window.removeEventListener('keyup', keyup);
 		window.removeEventListener('blur', clearMovement);

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -3,6 +3,7 @@ import { get, writable } from 'svelte/store';
 import { type Position, Geolocation } from '@capacitor/geolocation';
 import type { BackgroundGeolocationPlugin } from '@capacitor-community/background-geolocation';
 import { checkTripActive, currentTrip } from '$lib/trip';
+import { compassHeading } from '$lib/compass';
 import { bearingBetweenCoords, distanceBetweenCoords } from '$lib/utils';
 import { MIN_TRAVEL_DISTANCE_m } from '$lib/constants';
 import { appSettings } from './settings';
@@ -20,6 +21,7 @@ export const currentHeading = writable<number|null>(null);
 const HEADING_MIN_SPEED_mps = 0.5;
 const HEADING_MIN_DISTANCE_m = 5;
 let headingAnchor: {lat: number, lng: number}|null = null;
+let lastCourseTime = 0;
 
 currentPos.subscribe(pos => {
 	if (!pos) return;
@@ -31,7 +33,20 @@ currentPos.subscribe(pos => {
 		course = bearingBetweenCoords(headingAnchor.lat, headingAnchor.lng, latitude, longitude);
 	}
 	if (!headingAnchor || moved >= HEADING_MIN_DISTANCE_m) headingAnchor = { lat: latitude, lng: longitude };
-	if (course !== null) currentHeading.set(course);
+	if (course !== null) {
+		currentHeading.set(course);
+		lastCourseTime = Date.now();
+	}
+});
+
+// The GPS course wins while it's fresh (i.e. while moving); the compass takes
+// over when standing still, where the course is unavailable or stale
+const COMPASS_TAKEOVER_ms = 3000;
+
+compassHeading.subscribe(heading => {
+	if (heading === null) return;
+	if (Date.now() - lastCourseTime < COMPASS_TAKEOVER_ms) return;
+	currentHeading.set(heading);
 });
 
 let simulatedLocationActive = false;

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -3,13 +3,36 @@ import { get, writable } from 'svelte/store';
 import { type Position, Geolocation } from '@capacitor/geolocation';
 import type { BackgroundGeolocationPlugin } from '@capacitor-community/background-geolocation';
 import { checkTripActive, currentTrip } from '$lib/trip';
-import { distanceBetweenCoords } from '$lib/utils';
+import { bearingBetweenCoords, distanceBetweenCoords } from '$lib/utils';
 import { MIN_TRAVEL_DISTANCE_m } from '$lib/constants';
 import { appSettings } from './settings';
 
 export const currentPos = writable<Position|null>(null);
 export const bearingNorth = writable<boolean>(false);
 export const bearing = writable<number>(0);
+/** Last known traveling direction in degrees clockwise from north. */
+export const currentHeading = writable<number|null>(null);
+
+// The GPS course is meaningless while standing still (it drifts or freezes at
+// arbitrary values), so it's only trusted above a minimum speed; positions too
+// close together are likewise just accuracy noise, so the fallback bearing is
+// only computed once the anchor point is far enough behind
+const HEADING_MIN_SPEED_mps = 0.5;
+const HEADING_MIN_DISTANCE_m = 5;
+let headingAnchor: {lat: number, lng: number}|null = null;
+
+currentPos.subscribe(pos => {
+	if (!pos) return;
+	const { latitude, longitude, heading, speed } = pos.coords;
+	let course = typeof heading === 'number' && Number.isFinite(heading) && heading >= 0 &&
+		(speed == null || speed >= HEADING_MIN_SPEED_mps) ? heading % 360 : null;
+	const moved = headingAnchor ? distanceBetweenCoords(headingAnchor.lat, headingAnchor.lng, latitude, longitude) * 1000 : 0;
+	if (headingAnchor && moved >= HEADING_MIN_DISTANCE_m && course === null) {
+		course = bearingBetweenCoords(headingAnchor.lat, headingAnchor.lng, latitude, longitude);
+	}
+	if (!headingAnchor || moved >= HEADING_MIN_DISTANCE_m) headingAnchor = { lat: latitude, lng: longitude };
+	if (course !== null) currentHeading.set(course);
+});
 
 let simulatedLocationActive = false;
 

--- a/src/lib/map.svelte.ts
+++ b/src/lib/map.svelte.ts
@@ -299,7 +299,7 @@ export async function loadImages(map: maplibregl.Map) {
 	}
 
 	addOrReplace('pulsing-dot', pulsingDot(map), { pixelRatio: 2 });
-	addOrReplace('nav-marker', navigationMarker(), { pixelRatio: 2 });
+	addOrReplace('nav-marker', navigationMarker(150), { pixelRatio: 2 });
 	addOrReplace('bike_inactive', await loadSvg('./assets/bike_marker_inactive.svg', replaces));
 	addOrReplace('bike_inactive_selected', await loadSvg('./assets/bike_marker_inactive_selected.svg', replaces));
 	addOrReplace('dock_inactive', await loadSvg('./assets/dock_marker_inactive.svg', replaces));

--- a/src/lib/map.svelte.ts
+++ b/src/lib/map.svelte.ts
@@ -1,5 +1,5 @@
 import { get, writable } from 'svelte/store';
-import { pulsingDot } from '$lib/pulsing-dot';
+import { navigationMarker, pulsingDot } from '$lib/pulsing-dot';
 import type { GeoJSON } from 'geojson';
 import { getCssVariable } from '$lib/utils';
 import { theme } from '$lib/theme';
@@ -21,6 +21,9 @@ export type StationInfo ={
 export const stations = $state<{value:StationInfo[]}>({ value: [] });
 export const selectedStation = writable<string|null>(null);
 export const following = writable<boolean>(false);
+/** While following: 'north' is the classic top-down view, 'heading' the tilted
+ * navigation view that rotates with the traveling direction (trips only). */
+export const viewMode = writable<'north'|'heading'>('north');
 
 export function setSourceData(map: maplibregl.Map) {
 	const src = map.getSource('points');
@@ -267,7 +270,13 @@ export function addLayers(map: maplibregl.Map) {
 		'type': 'symbol',
 		'source': 'user-location',
 		'layout': {
-			'icon-image': 'pulsing-dot',
+			'icon-image': ['case', ['to-boolean', ['get', 'nav']], 'nav-marker', 'pulsing-dot'],
+			'icon-rotate': ['case', ['to-boolean', ['get', 'nav']], ['coalesce', ['get', 'heading'], 0], 0],
+			// rotate with the map and lie flat on it when tilted, like the route line
+			'icon-rotation-alignment': 'map',
+			'icon-pitch-alignment': 'map',
+			'icon-allow-overlap': true,
+			'icon-ignore-placement': true,
 		},
 	});
 }
@@ -290,6 +299,7 @@ export async function loadImages(map: maplibregl.Map) {
 	}
 
 	addOrReplace('pulsing-dot', pulsingDot(map), { pixelRatio: 2 });
+	addOrReplace('nav-marker', navigationMarker(), { pixelRatio: 2 });
 	addOrReplace('bike_inactive', await loadSvg('./assets/bike_marker_inactive.svg', replaces));
 	addOrReplace('bike_inactive_selected', await loadSvg('./assets/bike_marker_inactive_selected.svg', replaces));
 	addOrReplace('dock_inactive', await loadSvg('./assets/dock_marker_inactive.svg', replaces));

--- a/src/lib/map.svelte.ts
+++ b/src/lib/map.svelte.ts
@@ -299,7 +299,7 @@ export async function loadImages(map: maplibregl.Map) {
 	}
 
 	addOrReplace('pulsing-dot', pulsingDot(map), { pixelRatio: 2 });
-	addOrReplace('nav-marker', navigationMarker(150), { pixelRatio: 2 });
+	addOrReplace('nav-marker', navigationMarker(165), { pixelRatio: 2 });
 	addOrReplace('bike_inactive', await loadSvg('./assets/bike_marker_inactive.svg', replaces));
 	addOrReplace('bike_inactive_selected', await loadSvg('./assets/bike_marker_inactive_selected.svg', replaces));
 	addOrReplace('dock_inactive', await loadSvg('./assets/dock_marker_inactive.svg', replaces));

--- a/src/lib/marker-animation.test.ts
+++ b/src/lib/marker-animation.test.ts
@@ -94,6 +94,19 @@ describe('createMarkerAnimator', () => {
 		expect(applied.at(-1)?.lng).toBe(0.001); // and still reaches it on time
 	});
 
+	it('keeps the turn pacing when the heading is already the target', () => {
+		const applied: MarkerState[] = [];
+		const animator = createMarkerAnimator(state => applied.push(state));
+		animator.setTarget({ lng: 0, lat: 0, heading: 0 });
+		now += 1000;
+		animator.setTarget({ lng: 0.001, lat: 0, heading: 90 });
+		runFrame(500);
+		animator.setHeading(90); // the fix's own heading, notified late
+		runFrame(250);
+		// 750ms into the 1000ms turn — not re-timed into a 300ms sprint
+		expect(applied.at(-1)?.heading).toBe(67.5);
+	});
+
 	it('snaps instead of gliding across large jumps', () => {
 		const applied: MarkerState[] = [];
 		const animator = createMarkerAnimator(state => applied.push(state));

--- a/src/lib/marker-animation.test.ts
+++ b/src/lib/marker-animation.test.ts
@@ -87,7 +87,11 @@ describe('createMarkerAnimator', () => {
 		animator.setHeading(90);
 		runFrame(300);
 		expect(applied.at(-1)?.heading).toBe(90);
-		expect(applied.at(-1)?.lng).toBe(0.001); // the glide still reaches its target
+		// the position keeps its own timing: 800ms into a 1000ms glide, not rushed
+		// to the target by the heading change
+		expect(applied.at(-1)?.lng).toBeCloseTo(0.0008, 10);
+		runFrame(200);
+		expect(applied.at(-1)?.lng).toBe(0.001); // and still reaches it on time
 	});
 
 	it('snaps instead of gliding across large jumps', () => {

--- a/src/lib/marker-animation.test.ts
+++ b/src/lib/marker-animation.test.ts
@@ -77,6 +77,19 @@ describe('createMarkerAnimator', () => {
 		expect(applied.at(-1)?.heading).toBe(120);
 	});
 
+	it('retargets the heading without disturbing the position glide', () => {
+		const applied: MarkerState[] = [];
+		const animator = createMarkerAnimator(state => applied.push(state));
+		animator.setTarget({ lng: 0, lat: 0, heading: 0 });
+		now += 1000;
+		animator.setTarget({ lng: 0.001, lat: 0, heading: 0 });
+		runFrame(500); // halfway through the position glide
+		animator.setHeading(90);
+		runFrame(300);
+		expect(applied.at(-1)?.heading).toBe(90);
+		expect(applied.at(-1)?.lng).toBe(0.001); // the glide still reaches its target
+	});
+
 	it('snaps instead of gliding across large jumps', () => {
 		const applied: MarkerState[] = [];
 		const animator = createMarkerAnimator(state => applied.push(state));

--- a/src/lib/marker-animation.test.ts
+++ b/src/lib/marker-animation.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMarkerAnimator, shortestAngleDelta, type MarkerState } from '$lib/marker-animation';
+
+describe('shortestAngleDelta', () => {
+	it('rotates through the wrap-around when that is shorter', () => {
+		expect(shortestAngleDelta(350, 10)).toBe(20);
+		expect(shortestAngleDelta(10, 350)).toBe(-20);
+	});
+
+	it('handles plain rotations', () => {
+		expect(shortestAngleDelta(0, 90)).toBe(90);
+		expect(shortestAngleDelta(90, 45)).toBe(-45);
+		expect(shortestAngleDelta(0, 180)).toBe(-180);
+	});
+});
+
+describe('createMarkerAnimator', () => {
+	let now: number;
+	let frames: FrameRequestCallback[];
+
+	beforeEach(() => {
+		now = 1000;
+		frames = [];
+		vi.stubGlobal('performance', { now: () => now });
+		vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+			frames.push(cb);
+			return frames.length;
+		});
+		vi.stubGlobal('cancelAnimationFrame', () => {});
+	});
+
+	afterEach(() => vi.unstubAllGlobals());
+
+	function runFrame(advanceMs: number) {
+		now += advanceMs;
+		const pending = frames.splice(0, frames.length);
+		pending.forEach(cb => cb(now));
+	}
+
+	it('snaps to the first position immediately', () => {
+		const applied: MarkerState[] = [];
+		const animator = createMarkerAnimator(state => applied.push(state));
+		animator.setTarget({ lng: -9.15, lat: 38.744, heading: 45 });
+		expect(applied).toEqual([{ lng: -9.15, lat: 38.744, heading: 45 }]);
+	});
+
+	it('glides towards subsequent positions over the update interval', () => {
+		const applied: MarkerState[] = [];
+		const animator = createMarkerAnimator(state => applied.push(state));
+		animator.setTarget({ lng: 0, lat: 0, heading: 0 });
+		now += 1000;
+		animator.setTarget({ lng: 0.001, lat: 0.002, heading: 90 });
+		runFrame(500);
+		expect(applied.at(-1)).toEqual({ lng: 0.0005, lat: 0.001, heading: 45 });
+		runFrame(500);
+		expect(applied.at(-1)).toEqual({ lng: 0.001, lat: 0.002, heading: 90 });
+		expect(frames).toHaveLength(0); // animation finished
+	});
+
+	it('interpolates the heading along the shortest arc', () => {
+		const applied: MarkerState[] = [];
+		const animator = createMarkerAnimator(state => applied.push(state));
+		animator.setTarget({ lng: 0, lat: 0, heading: 350 });
+		now += 1000;
+		animator.setTarget({ lng: 0.001, lat: 0, heading: 10 });
+		runFrame(500);
+		expect(applied.at(-1)?.heading).toBe(0);
+	});
+
+	it('keeps the previous heading while it is unknown', () => {
+		const applied: MarkerState[] = [];
+		const animator = createMarkerAnimator(state => applied.push(state));
+		animator.setTarget({ lng: 0, lat: 0, heading: 120 });
+		now += 1000;
+		animator.setTarget({ lng: 0.001, lat: 0, heading: null });
+		runFrame(1000);
+		expect(applied.at(-1)?.heading).toBe(120);
+	});
+
+	it('snaps instead of gliding across large jumps', () => {
+		const applied: MarkerState[] = [];
+		const animator = createMarkerAnimator(state => applied.push(state));
+		animator.setTarget({ lng: -9.15, lat: 38.744, heading: 0 });
+		now += 1000;
+		animator.setTarget({ lng: -9.15, lat: 38.9, heading: null });
+		expect(applied.at(-1)).toEqual({ lng: -9.15, lat: 38.9, heading: 0 });
+		expect(frames).toHaveLength(0);
+	});
+});

--- a/src/lib/marker-animation.ts
+++ b/src/lib/marker-animation.ts
@@ -12,6 +12,7 @@ export function shortestAngleDelta(from: number, to: number): number {
 // is a relocation (first fix, GPS jump), not movement worth animating
 const MIN_GLIDE_ms = 200;
 const MAX_GLIDE_ms = 1500;
+const HEADING_GLIDE_ms = 300;
 const SNAP_DISTANCE_deg = 0.005; // ~500 m
 
 /**
@@ -68,10 +69,21 @@ export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 		}
 	}
 
+	/** Retarget only the heading (e.g. from the compass while standing still),
+	 * keeping any in-flight position glide aimed at its current target. */
+	function setHeading(heading: number) {
+		if (!displayed || !target) return;
+		from = displayed;
+		target = { ...target, heading };
+		startTime = performance.now();
+		duration = HEADING_GLIDE_ms;
+		if (frame === null) frame = requestAnimationFrame(step);
+	}
+
 	function stop() {
 		if (frame !== null) cancelAnimationFrame(frame);
 		frame = null;
 	}
 
-	return { setTarget, stop, displayed: () => displayed };
+	return { setTarget, setHeading, stop, displayed: () => displayed };
 }

--- a/src/lib/marker-animation.ts
+++ b/src/lib/marker-animation.ts
@@ -8,9 +8,11 @@ export function shortestAngleDelta(from: number, to: number): number {
 
 // GPS fixes land roughly once per second; gliding towards each one over the
 // time since the previous fix keeps the marker moving at a steady pace. The
-// clamp guards against bursts and long gaps, and anything past SNAP_DISTANCE
-// is a relocation (first fix, GPS jump), not movement worth animating
-const MIN_GLIDE_ms = 200;
+// clamp guards against long gaps, and anything past SNAP_DISTANCE is a
+// relocation (first fix, GPS jump), not movement worth animating.
+// There is deliberately no lower bound: updates can also arrive per frame (the
+// debug controls, a high-rate fix stream), and gliding those over a floor well
+// above their own interval would leave the marker permanently behind
 const MAX_GLIDE_ms = 1500;
 const HEADING_GLIDE_ms = 300;
 const SNAP_DISTANCE_deg = 0.005; // ~500 m
@@ -22,23 +24,45 @@ const SNAP_DISTANCE_deg = 0.005; // ~500 m
  */
 export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 	let displayed: MarkerState|null = null;
-	let from: MarkerState|null = null;
-	let target: MarkerState|null = null;
-	let startTime = 0;
-	let duration = 0;
+	// Position and heading glide on independent tracks: a compass heading can
+	// arrive mid-glide (and Svelte defers a store set made inside another store's
+	// notification, so even a fix's own heading lands after its position), and
+	// re-timing the position from those would cut the glide short and leave the
+	// marker sprinting between fixes and then stalling
+	let posFrom: { lng: number, lat: number }|null = null;
+	let posTarget: { lng: number, lat: number }|null = null;
+	let posStart = 0;
+	let posDuration = 0;
+	let headFrom = 0;
+	let headTarget = 0;
+	let headStart = 0;
+	let headDuration = 0;
 	let lastTargetTime: number|null = null;
 	let frame: number|null = null;
 
-	function step(time: number) {
+	/** Progress along a track, clamped to the segment it interpolates. */
+	function progress(start: number, duration: number, now: number) {
+		if (duration <= 0) return 1;
+		return Math.min(Math.max((now - start) / duration, 0), 1);
+	}
+
+	// Progress is measured with performance.now() rather than the frame timestamp
+	// handed to the callback: that timestamp marks the start of the frame, while
+	// the start times are taken when a target arrives, which on a busy frame (or
+	// a high refresh rate) is already past the next frame's timestamp — mixing
+	// the two makes progress negative and walks the marker backwards
+	function step() {
 		frame = null;
-		if (!from || !target) return;
-		const t = duration <= 0 ? 1 : Math.min((time - startTime) / duration, 1);
+		if (!posFrom || !posTarget) return;
+		const now = performance.now();
+		const tp = progress(posStart, posDuration, now);
+		const th = progress(headStart, headDuration, now);
 		displayed = {
-			lng: from.lng + (target.lng - from.lng) * t,
-			lat: from.lat + (target.lat - from.lat) * t,
-			heading: (from.heading + shortestAngleDelta(from.heading, target.heading) * t + 360) % 360,
+			lng: posFrom.lng + (posTarget.lng - posFrom.lng) * tp,
+			lat: posFrom.lat + (posTarget.lat - posFrom.lat) * tp,
+			heading: (headFrom + shortestAngleDelta(headFrom, headTarget) * th + 360) % 360,
 		};
-		if (t < 1) frame = requestAnimationFrame(step);
+		if (tp < 1 || th < 1) frame = requestAnimationFrame(step);
 		apply(displayed);
 	}
 
@@ -46,24 +70,32 @@ export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 		const time = performance.now();
 		// While the heading is unknown (stationary, first fixes) keep pointing
 		// the way we were last known to be going
-		const heading = next.heading ?? target?.heading ?? 0;
+		const heading = next.heading ?? headTarget;
 		const jumped = displayed !== null && (
 			Math.abs(next.lat - displayed.lat) > SNAP_DISTANCE_deg ||
 			Math.abs(next.lng - displayed.lng) > SNAP_DISTANCE_deg
 		);
-		target = { lng: next.lng, lat: next.lat, heading };
+		posTarget = { lng: next.lng, lat: next.lat };
 		if (displayed === null || jumped) {
-			from = target;
-			duration = 0;
+			posFrom = posTarget;
+			posDuration = 0;
+			headFrom = heading;
+			headDuration = 0;
 		} else {
-			from = displayed;
-			duration = Math.min(Math.max(lastTargetTime === null ? 0 : time - lastTargetTime, MIN_GLIDE_ms), MAX_GLIDE_ms);
+			posFrom = { lng: displayed.lng, lat: displayed.lat };
+			posDuration = Math.min(lastTargetTime === null ? 0 : time - lastTargetTime, MAX_GLIDE_ms);
+			// Turn across the same interval, so the marker rotates as steadily as
+			// it travels instead of snapping round on arrival
+			headFrom = displayed.heading;
+			headDuration = posDuration;
 		}
+		headTarget = heading;
 		lastTargetTime = time;
-		startTime = time;
-		if (duration <= 0) {
+		posStart = time;
+		headStart = time;
+		if (posDuration <= 0 && headDuration <= 0) {
 			if (frame !== null) cancelAnimationFrame(frame);
-			step(time);
+			step();
 		} else if (frame === null) {
 			frame = requestAnimationFrame(step);
 		}
@@ -72,11 +104,11 @@ export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 	/** Retarget only the heading (e.g. from the compass while standing still),
 	 * keeping any in-flight position glide aimed at its current target. */
 	function setHeading(heading: number) {
-		if (!displayed || !target) return;
-		from = displayed;
-		target = { ...target, heading };
-		startTime = performance.now();
-		duration = HEADING_GLIDE_ms;
+		if (!displayed || !posTarget) return;
+		headFrom = displayed.heading;
+		headTarget = heading;
+		headStart = performance.now();
+		headDuration = HEADING_GLIDE_ms;
 		if (frame === null) frame = requestAnimationFrame(step);
 	}
 

--- a/src/lib/marker-animation.ts
+++ b/src/lib/marker-animation.ts
@@ -117,6 +117,10 @@ export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 	 * keeping any in-flight position glide aimed at its current target. */
 	function setHeading(heading: number) {
 		if (!displayed || !posTarget) return;
+		// A fix's own heading is announced again after its position (the store
+		// notification is deferred) — re-timing the turn already in flight would
+		// compress every turn into the short compass glide
+		if (heading === headTarget) return;
 		headFrom = displayed.heading;
 		headTarget = heading;
 		headStart = performance.now();

--- a/src/lib/marker-animation.ts
+++ b/src/lib/marker-animation.ts
@@ -1,0 +1,77 @@
+export type MarkerState = { lng: number, lat: number, heading: number };
+export type MarkerTarget = { lng: number, lat: number, heading: number|null };
+
+/** Signed shortest rotation (-180, 180] to get from one bearing to another. */
+export function shortestAngleDelta(from: number, to: number): number {
+	return ((to - from + 540) % 360) - 180;
+}
+
+// GPS fixes land roughly once per second; gliding towards each one over the
+// time since the previous fix keeps the marker moving at a steady pace. The
+// clamp guards against bursts and long gaps, and anything past SNAP_DISTANCE
+// is a relocation (first fix, GPS jump), not movement worth animating
+const MIN_GLIDE_ms = 200;
+const MAX_GLIDE_ms = 1500;
+const SNAP_DISTANCE_deg = 0.005; // ~500 m
+
+/**
+ * Glides a marker between position updates instead of teleporting it.
+ * `apply` is called with the interpolated state on every animation frame
+ * (and synchronously when a target snaps).
+ */
+export function createMarkerAnimator(apply: (state: MarkerState) => void) {
+	let displayed: MarkerState|null = null;
+	let from: MarkerState|null = null;
+	let target: MarkerState|null = null;
+	let startTime = 0;
+	let duration = 0;
+	let lastTargetTime: number|null = null;
+	let frame: number|null = null;
+
+	function step(time: number) {
+		frame = null;
+		if (!from || !target) return;
+		const t = duration <= 0 ? 1 : Math.min((time - startTime) / duration, 1);
+		displayed = {
+			lng: from.lng + (target.lng - from.lng) * t,
+			lat: from.lat + (target.lat - from.lat) * t,
+			heading: (from.heading + shortestAngleDelta(from.heading, target.heading) * t + 360) % 360,
+		};
+		if (t < 1) frame = requestAnimationFrame(step);
+		apply(displayed);
+	}
+
+	function setTarget(next: MarkerTarget) {
+		const time = performance.now();
+		// While the heading is unknown (stationary, first fixes) keep pointing
+		// the way we were last known to be going
+		const heading = next.heading ?? target?.heading ?? 0;
+		const jumped = displayed !== null && (
+			Math.abs(next.lat - displayed.lat) > SNAP_DISTANCE_deg ||
+			Math.abs(next.lng - displayed.lng) > SNAP_DISTANCE_deg
+		);
+		target = { lng: next.lng, lat: next.lat, heading };
+		if (displayed === null || jumped) {
+			from = target;
+			duration = 0;
+		} else {
+			from = displayed;
+			duration = Math.min(Math.max(lastTargetTime === null ? 0 : time - lastTargetTime, MIN_GLIDE_ms), MAX_GLIDE_ms);
+		}
+		lastTargetTime = time;
+		startTime = time;
+		if (duration <= 0) {
+			if (frame !== null) cancelAnimationFrame(frame);
+			step(time);
+		} else if (frame === null) {
+			frame = requestAnimationFrame(step);
+		}
+	}
+
+	function stop() {
+		if (frame !== null) cancelAnimationFrame(frame);
+		frame = null;
+	}
+
+	return { setTarget, stop, displayed: () => displayed };
+}

--- a/src/lib/marker-animation.ts
+++ b/src/lib/marker-animation.ts
@@ -39,11 +39,28 @@ export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 	let headDuration = 0;
 	let lastTargetTime: number|null = null;
 	let frame: number|null = null;
+	let smoothing = true;
 
 	/** Progress along a track, clamped to the segment it interpolates. */
 	function progress(start: number, duration: number, now: number) {
 		if (duration <= 0) return 1;
 		return Math.min(Math.max((now - start) / duration, 0), 1);
+	}
+
+	/** How long a track may take, which is no time at all without smoothing. */
+	function glide(duration: number) {
+		return smoothing ? duration : 0;
+	}
+
+	/** Render straight away once nothing is left to animate, otherwise keep the
+	 * animation loop running. */
+	function advance(settled: boolean) {
+		if (settled) {
+			if (frame !== null) cancelAnimationFrame(frame);
+			step();
+		} else if (frame === null) {
+			frame = requestAnimationFrame(step);
+		}
 	}
 
 	// Progress is measured with performance.now() rather than the frame timestamp
@@ -83,7 +100,7 @@ export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 			headDuration = 0;
 		} else {
 			posFrom = { lng: displayed.lng, lat: displayed.lat };
-			posDuration = Math.min(lastTargetTime === null ? 0 : time - lastTargetTime, MAX_GLIDE_ms);
+			posDuration = glide(Math.min(lastTargetTime === null ? 0 : time - lastTargetTime, MAX_GLIDE_ms));
 			// Turn across the same interval, so the marker rotates as steadily as
 			// it travels instead of snapping round on arrival
 			headFrom = displayed.heading;
@@ -93,12 +110,7 @@ export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 		lastTargetTime = time;
 		posStart = time;
 		headStart = time;
-		if (posDuration <= 0 && headDuration <= 0) {
-			if (frame !== null) cancelAnimationFrame(frame);
-			step();
-		} else if (frame === null) {
-			frame = requestAnimationFrame(step);
-		}
+		advance(posDuration <= 0 && headDuration <= 0);
 	}
 
 	/** Retarget only the heading (e.g. from the compass while standing still),
@@ -108,8 +120,19 @@ export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 		headFrom = displayed.heading;
 		headTarget = heading;
 		headStart = performance.now();
-		headDuration = HEADING_GLIDE_ms;
-		if (frame === null) frame = requestAnimationFrame(step);
+		headDuration = glide(HEADING_GLIDE_ms);
+		advance(headDuration <= 0);
+	}
+
+	/** Turning smoothing off drops the marker straight onto every update from
+	 * then on, and settles any glide already in flight. */
+	function setSmoothing(enabled: boolean) {
+		if (smoothing === enabled) return;
+		smoothing = enabled;
+		if (enabled || !posTarget) return;
+		posDuration = 0;
+		headDuration = 0;
+		advance(true);
 	}
 
 	function stop() {
@@ -117,5 +140,5 @@ export function createMarkerAnimator(apply: (state: MarkerState) => void) {
 		frame = null;
 	}
 
-	return { setTarget, setHeading, stop, displayed: () => displayed };
+	return { setTarget, setHeading, setSmoothing, stop, displayed: () => displayed };
 }

--- a/src/lib/pulsing-dot.ts
+++ b/src/lib/pulsing-dot.ts
@@ -12,11 +12,20 @@ export function navigationMarker(size = 100): ImageData {
 	canvas.height = size;
 	const context = canvas.getContext('2d')!;
 	const s = size / 100;
+	// Each corner is filleted with arcTo, entering and leaving through the edge
+	// midpoints; the tip is kept a touch sharper so the arrow stays directional
+	const corners = [
+		{ x: 50, y: 14, r: 4 }, // tip
+		{ x: 80, y: 84, r: 5 }, // right wing
+		{ x: 50, y: 66, r: 5 }, // tail notch
+		{ x: 20, y: 84, r: 5 }, // left wing
+	];
 	const arrow = new Path2D;
-	arrow.moveTo(50 * s, 14 * s); // tip
-	arrow.lineTo(80 * s, 84 * s); // right wing
-	arrow.lineTo(50 * s, 66 * s); // tail notch
-	arrow.lineTo(20 * s, 84 * s); // left wing
+	arrow.moveTo((corners[3].x + corners[0].x) / 2 * s, (corners[3].y + corners[0].y) / 2 * s);
+	corners.forEach((corner, i) => {
+		const next = corners[(i + 1) % corners.length];
+		arrow.arcTo(corner.x * s, corner.y * s, (corner.x + next.x) / 2 * s, (corner.y + next.y) / 2 * s, corner.r * s);
+	});
 	arrow.closePath();
 	context.lineJoin = 'round';
 	context.strokeStyle = 'white';

--- a/src/lib/pulsing-dot.ts
+++ b/src/lib/pulsing-dot.ts
@@ -1,6 +1,35 @@
 import type { StyleImageInterface } from 'maplibre-gl';
 import { getCssVariable } from '$lib/utils';
 
+/**
+ * The trip heading indicator: a navigation chevron in the same visual language
+ * as the pulsing dot (primary fill, white outline, soft shadow). Drawn pointing
+ * north; the map layer rotates it to the traveling direction.
+ */
+export function navigationMarker(size = 100): ImageData {
+	const canvas = document.createElement('canvas');
+	canvas.width = size;
+	canvas.height = size;
+	const context = canvas.getContext('2d')!;
+	const s = size / 100;
+	const arrow = new Path2D;
+	arrow.moveTo(50 * s, 14 * s); // tip
+	arrow.lineTo(80 * s, 84 * s); // right wing
+	arrow.lineTo(50 * s, 66 * s); // tail notch
+	arrow.lineTo(20 * s, 84 * s); // left wing
+	arrow.closePath();
+	context.lineJoin = 'round';
+	context.strokeStyle = 'white';
+	context.lineWidth = 6 * s;
+	context.shadowColor = 'rgba(0, 0, 0, 0.35)';
+	context.shadowBlur = 6 * s;
+	context.stroke(arrow);
+	context.shadowBlur = 0;
+	context.fillStyle = getCssVariable('--color-primary');
+	context.fill(arrow);
+	return context.getImageData(0, 0, size, size);
+}
+
 // This implements `StyleImageInterface`
 // to draw a pulsing dot icon on the map.
 export function pulsingDot(map: maplibregl.Map, size = 100, animationDuration = 1500) : StyleImageInterface {

--- a/src/lib/routing.ts
+++ b/src/lib/routing.ts
@@ -371,6 +371,10 @@ currentTrip.subscribe(trip => {
 currentRoute.subscribe(route => {
 	const trip = get(currentTrip);
 	if (!trip) return;
+	// A transiently failed recompute clears the route while the destination is
+	// still set — keep the last known metrics rather than collapsing the trip
+	// HUD (and shuffling everything anchored to it) until the next one lands
+	if (!route && get(routeDestination) !== null) return;
 	const destination = route ? { lat: route.destination.lat, lng: route.destination.lng } : null;
 	const distanceLeft = route ? route.totalDistance / 1000 : null;
 	const arrivalTime = route ? new Date(Date.now() + route.totalDuration * 1000) : null;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -10,6 +10,9 @@ export type AppSettings = {
 	theme: 'light'|'dark'|'system'|'daylight';
 	locale: 'pt'|'en'|'system';
 	updateWarning: boolean;
+	/** Development only: glide the location marker and the camera between fixes
+	 * instead of placing them straight onto each one. */
+	markerSmoothing: boolean;
 }
 
 export const appSettings = writable<AppSettings>();
@@ -23,7 +26,8 @@ export async function loadSettings() {
 	const theme = ((await Preferences.get({ key: 'settings/theme' })).value || 'system') as 'light'|'dark'|'system'|'daylight';
 	const locale = ((await Preferences.get({ key: 'settings/locale' })).value || 'system') as 'pt'|'en'|'system';
 	const updateWarning = (await Preferences.get({ key: 'settings/updateWarning' })).value !== 'false';
-	appSettings.set({ distanceLock, mockUnlock, backgroundLocation, analytics, theme, locale, updateWarning, reportRatings });
+	const markerSmoothing = (await Preferences.get({ key: 'settings/markerSmoothing' })).value !== 'false';
+	appSettings.set({ distanceLock, mockUnlock, backgroundLocation, analytics, theme, locale, updateWarning, reportRatings, markerSmoothing });
 
 	// Track previous values to only save changed settings
 	let prev: AppSettings | undefined;
@@ -41,6 +45,7 @@ export async function loadSettings() {
 		if (v.theme !== prev.theme) Preferences.set({ key: 'settings/theme', value: v.theme });
 		if (v.locale !== prev.locale) Preferences.set({ key: 'settings/locale', value: v.locale });
 		if (v.updateWarning !== prev.updateWarning) Preferences.set({ key: 'settings/updateWarning', value: v.updateWarning.toString() });
+		if (v.markerSmoothing !== prev.markerSmoothing) Preferences.set({ key: 'settings/markerSmoothing', value: v.markerSmoothing.toString() });
 		prev = { ...v };
 	});
 }

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -365,6 +365,14 @@ const translations = {
 		en: 'Simulate reservation and unlocking of bicycles in development mode',
 		pt: 'Simular a reserva e desbloqueio de bicicletas em modo de desenvolvimento',
 	},
+	marker_smoothing_setting_label: {
+		en: 'Smooth location marker',
+		pt: 'Suavizar marcador de localização',
+	},
+	marker_smoothing_setting_description: {
+		en: 'Glide the marker and the map between location updates instead of placing them straight onto each one',
+		pt: 'Deslizar o marcador e o mapa entre atualizações de localização em vez de os colocar diretamente em cada uma',
+	},
 	report_ratings_setting_label: {
 		en: 'Share trip ratings',
 		pt: 'Partilhar avaliações de viagens',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,6 +22,14 @@ export function distanceBetweenCoords(lat1:number, lon1:number, lat2:number, lon
 	return d;
 }
 
+/** Initial bearing in degrees (0-360, clockwise from north) from point 1 to point 2. */
+export function bearingBetweenCoords(lat1:number, lon1:number, lat2:number, lon2:number) {
+	const y = Math.sin(deg2rad(lon2 - lon1)) * Math.cos(deg2rad(lat2));
+	const x = Math.cos(deg2rad(lat1)) * Math.sin(deg2rad(lat2)) -
+		Math.sin(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) * Math.cos(deg2rad(lon2 - lon1));
+	return (Math.atan2(y, x) * 180 / Math.PI + 360) % 360;
+}
+
 export function formatDistance(distance:number) {
 	if (distance < 1) return `${(distance * 1000).toFixed(0)}m`;
 	return `${distance.toLocaleString(undefined, { maximumFractionDigits: 2, useGrouping: false })}km`;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,6 +31,7 @@
 	import Dialog from '$lib/components/Dialog.svelte';
 
 	let backListener: PluginListenerHandle;
+	let innerHeight = $state(0);
 	let menuHeight = $state(0);
 	let stationMenuPos:number|undefined = $state(0);
 	let tripStatusHeight:number = $state(0);
@@ -70,6 +71,8 @@
 	});
 </script>
 
+<svelte:window bind:innerHeight />
+
 <div class="h-full w-full relative overflow-hidden">
 	{#if $token === null}
 		<div transition:fade={{ duration: 150 }} class="absolute w-full h-full z-20 flex items-center justify-center">
@@ -91,7 +94,9 @@
 		<NetworkWarning {tripStatusHeight} {tripStatusWidth} />
 	{/if}
 
-	<Floating right={20} y={stationMenuPos} bottom offset={20}>
+	<!-- during a trip the station menu is unmounted and its position is a stale
+		snapshot of the previous orientation — anchor to the window bottom instead -->
+	<Floating right={20} y={$currentTrip !== null ? innerHeight : stationMenuPos} bottom offset={20}>
 		<LocationButton bind:locationPermission />
 	</Floating>
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #71.

## What

Adds a proper navigation view during trips: the camera tilts and rotates with the traveling direction, a chevron shows the heading, and the location marker glides smoothly between GPS fixes (also outside trips) instead of teleporting.

### Gliding location marker (`src/lib/marker-animation.ts`)
- A rAF-driven animator interpolates the `user-location` point between fixes, gliding over the interval since the previous fix (clamped 200ms–1.5s) so movement looks constant-speed; jumps over ~500 m (first fix, GPS glitches) snap instead of streaking across the city
- Heading rotations interpolate along the shortest arc, and can be retargeted mid-glide (compass updates) without disturbing the position animation

### Heading (`location.ts` + `src/lib/compass.ts`)
- `currentHeading` uses the GPS course when moving (trusted above 0.5 m/s), falls back to the bearing between fixes ≥5 m apart, and hands over to the device compass ~3 s after the course goes stale — so the chevron keeps tracking while turning on the spot
- Compass readings come from `webkitCompassHeading` on iOS (motion permission requested on the first location/compass button tap, as iOS requires a user gesture) and `deviceorientationabsolute` elsewhere (no permission, starts with the app), corrected for screen orientation and throttled to ≥2° changes at ≤5 Hz

### Navigation view
- Trip start eases the camera to pitch 50 / zoom 17, aligned to the heading, with the marker held in the lower part of the view so the road ahead is visible; while following, the camera is pinned to the gliding marker every frame; trip end eases back to north-up top-down
- The marker becomes a navigation chevron during trips, drawn in the pulsing dot's visual language (primary fill, white outline, soft shadow) and ground-aligned; since tilt foreshortens it, it scales with pitch (full size tilted, 80% flat) so it reads the same in both views
- Route lines thicken (5→8 px) while riding for legibility
- The camera re-aligns when the viewport or HUD layout changes (device rotation), and restarts the enter transition if a relayout lands mid-ease

### Controls
- The location button gains a third state: tapping while following on a trip toggles between the navigation view (arrow icon) and the north-up view (crosshair); off-trip behavior is unchanged
- The compass button now exits the navigation view (it's always visible then, since the map rarely points north); dragging still unfollows, and manually rotating the map now unfollows too
- Programmatic camera motion is distinguished from gestures via `originalEvent`, so tap-to-set-destination keeps working while the camera rotates every frame

## Test plan
- [x] `bun run check`, lint on touched files, `bunx vitest run` (8 new marker-animation tests; full suite passes)
- [x] On-bike testing (Android): glide, chevron, tilt/rotation, legibility tweaks, device-rotation re-centering fix
- [ ] iOS testing (compass permission prompt path)
