### PR TITLE
Declutter the map at low zoom with station dots

### DIFF
--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -2,7 +2,7 @@
 	import { token } from '$lib/account';
 	import { bearing, bearingNorth, currentHeading, currentPos } from '$lib/location';
 	import { getMapStyle } from '$lib/map-style';
-	import { addLayers, following, loadImages, selectedStation, setSourceData, stations, viewMode } from '$lib/map.svelte';
+	import { addLayers, following, loadImages, selectedStation, setSourceData, stationDotColor, stationIcon, stations, viewMode } from '$lib/map.svelte';
 	import { appSettings } from '$lib/settings';
 	import { createMarkerAnimator, type MarkerState } from '$lib/marker-animation';
 	import { computeRoute, currentRoute, routeDestination, type PlannedRoute } from '$lib/routing';
@@ -13,7 +13,7 @@
 	import { currentTrip, type ActiveTrip } from '$lib/trip';
 	import type { Position } from '@capacitor/geolocation';
 	import type { GeoJSON } from 'geojson';
-	import maplibregl from 'maplibre-gl';
+	import maplibregl, { type ExpressionSpecification } from 'maplibre-gl';
 	import { onMount, tick } from 'svelte';
 	import { get } from 'svelte/store';
 	import { fade } from 'svelte/transition';
@@ -280,6 +280,9 @@
 	// destination takes a deliberate hold instead. Detected from the pointer
 	// tracking rather than from clicks, because mobile webviews don't reliably
 	// emit a click for a long press
+	// every layer a station can be tapped through, whatever its current form
+	const STATION_LAYERS = ['points', 'docks', 'route-stations', 'station-dots'];
+
 	const TRIP_PIN_HOLD_ms = 400;
 	const TRIP_PIN_HOLD_TOLERANCE_px = 10;
 	let press: { id: number, x: number, y: number, time: number }|null = null;
@@ -290,7 +293,7 @@
 		const rect = map.getCanvasContainer().getBoundingClientRect();
 		const point: [number, number] = [e.clientX - rect.left, e.clientY - rect.top];
 		// releases over a dock open its menu through the regular click path
-		if (map.queryRenderedFeatures(point, { layers: ['points', 'docks'] }).length > 0) return;
+		if (map.queryRenderedFeatures(point, { layers: STATION_LAYERS }).length > 0) return;
 		schedulePinDrop(map.unproject(point));
 	}
 
@@ -334,14 +337,13 @@
 				});
 			}
 		}
-		map.on('click', 'points', onStationClick);
-		map.on('click', 'docks', onStationClick);
+		for (const layer of STATION_LAYERS) map.on('click', layer, onStationClick);
 		// on dragging map, remove user tracking
 		map.on('dragstart', () => {
 			following.set(false);
 		});
 		map.on('click', e => {
-			const features = map.queryRenderedFeatures(e.point, { layers: ['points', 'docks'] });
+			const features = map.queryRenderedFeatures(e.point, { layers: STATION_LAYERS });
 			if (features.length > 0) return;
 			if (get(selectedStation) != null) {
 				selectedStation.set(null);
@@ -464,6 +466,40 @@
 		});
 	}
 
+	function routeStationSerials(route: PlannedRoute|null): string[] {
+		if (!route) return [];
+		const serials = [route.startStationSerial, route.endStationSerial];
+		if (route.destination.type === 'station') serials.push(route.destination.stationSerial);
+		return [...new Set(serials.filter((s): s is string => s != null))];
+	}
+
+	// How stations are drawn depends on the trip (bike counts vs free docks)
+	// and the route on display: the route's own stations — plus the selected
+	// one — keep their full markers at every zoom while the rest step back:
+	// dimmed, and mere dots below the marker zoom, where the route line and
+	// the map must stay legible
+	function applyStationDisplayState() {
+		if (!mapLoaded || map.getLayer('points') == null) return;
+		const trip = get(currentTrip) !== null;
+		map.setLayoutProperty('points', 'visibility', trip ? 'none' : 'visible');
+		map.setLayoutProperty('docks', 'visibility', trip ? 'visible' : 'none');
+		map.setLayoutProperty('route-stations', 'icon-image', stationIcon(trip ? 'dock' : 'bike', trip ? 'freeDocks' : 'bikes'));
+		map.setPaintProperty('station-dots', 'circle-color', stationDotColor(trip ? 'freeDocks' : 'bikes'));
+		const routeSerials = routeStationSerials(get(currentRoute));
+		const selected = get(selectedStation);
+		const fullMarkerSerials = selected != null && !routeSerials.includes(selected) ? [...routeSerials, selected] : routeSerials;
+		const fullMarker: ExpressionSpecification = ['in', ['get', 'serialNumber'], ['literal', fullMarkerSerials]];
+		map.setFilter('route-stations', fullMarker);
+		// those stations get a full marker instead of a dot
+		map.setFilter('station-dots', fullMarkerSerials.length ? ['!', fullMarker] : null);
+		const dotOpacity = routeSerials.length ? 0.4 : 1;
+		map.setPaintProperty('station-dots', 'circle-opacity', dotOpacity);
+		map.setPaintProperty('station-dots', 'circle-stroke-opacity', dotOpacity);
+		const markerOpacity: ExpressionSpecification|number = routeSerials.length ? ['case', fullMarker, 1, 0.4] : 1;
+		map.setPaintProperty('points', 'icon-opacity', markerOpacity);
+		map.setPaintProperty('docks', 'icon-opacity', markerOpacity);
+	}
+
 	// The station menu height passed as bottomPadding only measures the bike
 	// list; the sheet header (drag handle + station info) adds roughly this much
 	const SHEET_HEADER_px = 110;
@@ -509,6 +545,7 @@
 		routeClippingState = emptyRouteClippingState();
 		if (!mapLoaded) return;
 		applyRouteData(route);
+		applyStationDisplayState();
 		if (!route) {
 			pendingFit = false;
 			return;
@@ -604,6 +641,7 @@
 			mapLoaded = true;
 			setSourceData(map);
 			addLayers(map);
+			applyStationDisplayState();
 			renderUserMarker();
 			updateMarkerScale();
 			applyRouteData(get(currentRoute));
@@ -624,6 +662,7 @@
 				loadImages(map);
 				setSourceData(map);
 				addLayers(map);
+				applyStationDisplayState();
 				renderUserMarker();
 				updateMarkerScale();
 				applyRouteData(get(currentRoute));
@@ -649,8 +688,7 @@
 			renderUserMarker();
 		}
 		if (mapLoaded) {
-			map.setLayoutProperty('points', 'visibility', trip ? 'none' : 'visible');
-			map.setLayoutProperty('docks', 'visibility', trip ? 'visible' : 'none');
+			applyStationDisplayState();
 			// while riding, the route has to stay legible at a glance, so thicken it
 			map.setPaintProperty('route-outline', 'line-width', trip ? 12 : 9);
 			map.setPaintProperty('route-bike', 'line-width', trip ? 8 : 5);
@@ -663,6 +701,7 @@
 			$selectedStation = $selectedStation;
 			if (mapLoaded) {
 				setSourceData(map);
+				applyStationDisplayState();
 			}
 		}
 	});

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -2,7 +2,7 @@
 	import { token } from '$lib/account';
 	import { bearing, bearingNorth, currentHeading, currentPos } from '$lib/location';
 	import { getMapStyle } from '$lib/map-style';
-	import { addLayers, following, loadImages, selectedStation, setSourceData, stationDotColor, stationIcon, stations, viewMode } from '$lib/map.svelte';
+	import { addLayers, following, loadImages, selectedStation, setSourceData, STATION_MARKER_FADE_END, STATION_MARKER_FADE_START, stationDotColor, stationDotStrokeColor, stationIcon, stations, viewMode } from '$lib/map.svelte';
 	import { appSettings } from '$lib/settings';
 	import { createMarkerAnimator, type MarkerState } from '$lib/marker-animation';
 	import { computeRoute, currentRoute, routeDestination, type PlannedRoute } from '$lib/routing';
@@ -475,9 +475,10 @@
 
 	// How stations are drawn depends on the trip (bike counts vs free docks)
 	// and the route on display: the route's own stations — plus the selected
-	// one — keep their full markers at every zoom while the rest step back:
-	// dimmed, and mere dots below the marker zoom, where the route line and
-	// the map must stay legible
+	// one — keep a full-size marker at every zoom (via the route-stations
+	// layer, hidden from the regular ones) while the rest step back: dimmed,
+	// and mere dots below the marker zoom, where the route line and the map
+	// must stay legible
 	function applyStationDisplayState() {
 		if (!mapLoaded || map.getLayer('points') == null) return;
 		const trip = get(currentTrip) !== null;
@@ -485,17 +486,20 @@
 		map.setLayoutProperty('docks', 'visibility', trip ? 'visible' : 'none');
 		map.setLayoutProperty('route-stations', 'icon-image', stationIcon(trip ? 'dock' : 'bike', trip ? 'freeDocks' : 'bikes'));
 		map.setPaintProperty('station-dots', 'circle-color', stationDotColor(trip ? 'freeDocks' : 'bikes'));
+		map.setPaintProperty('station-dots', 'circle-stroke-color', stationDotStrokeColor(trip ? 'freeDocks' : 'bikes'));
 		const routeSerials = routeStationSerials(get(currentRoute));
 		const selected = get(selectedStation);
 		const fullMarkerSerials = selected != null && !routeSerials.includes(selected) ? [...routeSerials, selected] : routeSerials;
 		const fullMarker: ExpressionSpecification = ['in', ['get', 'serialNumber'], ['literal', fullMarkerSerials]];
 		map.setFilter('route-stations', fullMarker);
-		// those stations get a full marker instead of a dot
+		// those stations get a full marker instead of a dot or a growing pin
 		map.setFilter('station-dots', fullMarkerSerials.length ? ['!', fullMarker] : null);
-		const dotOpacity = routeSerials.length ? 0.4 : 1;
+		const dim = routeSerials.length ? 0.4 : 1;
+		const dotOpacity: ExpressionSpecification = ['interpolate', ['linear'], ['zoom'],
+			STATION_MARKER_FADE_START, dim, STATION_MARKER_FADE_END, 0];
 		map.setPaintProperty('station-dots', 'circle-opacity', dotOpacity);
 		map.setPaintProperty('station-dots', 'circle-stroke-opacity', dotOpacity);
-		const markerOpacity: ExpressionSpecification|number = routeSerials.length ? ['case', fullMarker, 1, 0.4] : 1;
+		const markerOpacity: ExpressionSpecification|number = fullMarkerSerials.length ? ['case', fullMarker, 0, dim] : dim;
 		map.setPaintProperty('points', 'icon-opacity', markerOpacity);
 		map.setPaintProperty('docks', 'icon-opacity', markerOpacity);
 	}

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -494,9 +494,8 @@
 		map.setFilter('route-stations', fullMarker);
 		// those stations get a full marker instead of a dot or a growing pin
 		map.setFilter('station-dots', fullMarkerSerials.length ? ['!', fullMarker] : null);
-		const dim = routeSerials.length ? 0.4 : 1;
-		const dotOpacity: ExpressionSpecification = ['interpolate', ['linear'], ['zoom'],
-			STATION_MARKER_FADE_START, dim, STATION_MARKER_FADE_END, 0];
+		const dim = routeSerials.length ? 0.6 : 1;
+		const dotOpacity: ExpressionSpecification = ['interpolate', ['linear'], ['zoom'], STATION_MARKER_FADE_START, dim, STATION_MARKER_FADE_END, 0];
 		map.setPaintProperty('station-dots', 'circle-opacity', dotOpacity);
 		map.setPaintProperty('station-dots', 'circle-stroke-opacity', dotOpacity);
 		const markerOpacity: ExpressionSpecification|number = fullMarkerSerials.length ? ['case', fullMarker, 0, dim] : dim;

--- a/src/lib/map.svelte.ts
+++ b/src/lib/map.svelte.ts
@@ -3,7 +3,7 @@ import { navigationMarker, pulsingDot } from '$lib/pulsing-dot';
 import type { GeoJSON } from 'geojson';
 import { getCssVariable } from '$lib/utils';
 import { theme } from '$lib/theme';
-import maplibregl from 'maplibre-gl';
+import maplibregl, { type ExpressionSpecification } from 'maplibre-gl';
 import { currentPos } from '$lib/location';
 
 export type StationInfo ={
@@ -123,8 +123,51 @@ export async function loadSvg(url: string, replaces?:Record<string, string>): Pr
 	});
 }
 
+/** Below this zoom stations are drawn as small dots instead of full markers,
+ * so a zoomed-out map (e.g. framing a computed route) isn't buried under pins. */
+export const STATION_MARKER_MIN_ZOOM = 14;
+
+/** Marker for a station: a pin with the count of bikes or free docks baked in,
+ * with selected/inactive variants. */
+export function stationIcon(kind: 'bike'|'dock', countProp: 'bikes'|'freeDocks'): ExpressionSpecification {
+	return ['case',
+		['get', 'selected'],
+		['case',
+			['get', 'inService'],
+			['concat', kind + '_selected-', ['get', countProp]],
+			kind + '_inactive_selected'],
+		['case',
+			['get', 'inService'],
+			['concat', kind + '-', ['get', countProp]],
+			kind + '_inactive']];
+}
+
+/** Dot for a station at low zoom: accent when it has something to offer
+ * (bikes or free docks, depending on the trip state), muted otherwise. */
+export function stationDotColor(countProp: 'bikes'|'freeDocks'): ExpressionSpecification {
+	return ['case',
+		['all', ['get', 'inService'], ['>', ['get', countProp], 0]],
+		getCssVariable('--color-primary'),
+		getCssVariable('--color-label')];
+}
+
 export function addLayers(map: maplibregl.Map) {
 	if (map.getLayer('points') != undefined) return;
+	// Added first so every later insertion before 'building' (trip path, route,
+	// destination pin) lands above it — at low zoom the route must cover the
+	// dots, not the other way around
+	map.addLayer({
+		'id': 'station-dots',
+		'type': 'circle',
+		'source': 'points',
+		'maxzoom': STATION_MARKER_MIN_ZOOM,
+		'paint': {
+			'circle-radius': ['interpolate', ['linear'], ['zoom'], 11, 3, STATION_MARKER_MIN_ZOOM, 5],
+			'circle-color': stationDotColor('bikes'),
+			'circle-stroke-width': 1.5,
+			'circle-stroke-color': getCssVariable('--color-background'),
+		},
+	}, 'building');
 	map.addLayer({
 		'id': 'trip-path-outline',
 		'type': 'line',
@@ -217,23 +260,11 @@ export function addLayers(map: maplibregl.Map) {
 		'id': 'points',
 		'type': 'symbol',
 		'source': 'points',
+		'minzoom': STATION_MARKER_MIN_ZOOM,
 		'layout': {
-			// bike if selected, bike_selected otherwise
-			// 'icon-image': ['case', ['get', 'selected'], ['concat', 'bike_selected-', ['get', 'bikes']], ['concat', 'bike-', ['get', 'bikes']]],
-			// Add case for inService and selected
 			visibility: 'visible',
-			'icon-image': ['case',
-				['get', 'selected'],
-				['case',
-					['get', 'inService'],
-					['concat', 'bike_selected-', ['get', 'bikes']],
-					'bike_inactive_selected'],
-				['case',
-					['get', 'inService'],
-					['concat', 'bike-', ['get', 'bikes']],
-					'bike_inactive']],
-
-			'icon-size': ['interpolate', ['linear'], ['zoom'], 11, 0.3, 13, 0.5],
+			'icon-image': stationIcon('bike', 'bikes'),
+			'icon-size': 0.5,
 			'icon-anchor': 'bottom',
 			'icon-allow-overlap': true,
 			'icon-padding': 0,
@@ -243,23 +274,29 @@ export function addLayers(map: maplibregl.Map) {
 		'id': 'docks',
 		'type': 'symbol',
 		'source': 'points',
+		'minzoom': STATION_MARKER_MIN_ZOOM,
 		'layout': {
-			// bike if selected, bike_selected otherwise
-			// 'icon-image': ['case', ['get', 'selected'], ['concat', 'bike_selected-', ['get', 'bikes']], ['concat', 'bike-', ['get', 'bikes']]],
-			// Add case for inService and selected
 			visibility: 'none',
-			'icon-image': ['case',
-				['get', 'selected'],
-				['case',
-					['get', 'inService'],
-					['concat', 'dock_selected-', ['get', 'freeDocks']],
-					'dock_inactive_selected'],
-				['case',
-					['get', 'inService'],
-					['concat', 'dock-', ['get', 'freeDocks']],
-					'dock_inactive']],
-
-			'icon-size': ['interpolate', ['linear'], ['zoom'], 11, 0.3, 13, 0.5],
+			'icon-image': stationIcon('dock', 'freeDocks'),
+			'icon-size': 0.5,
+			'icon-anchor': 'bottom',
+			'icon-allow-overlap': true,
+			'icon-padding': 0,
+		},
+	});
+	// The stations that matter right now (the route's pickup/dropoff/
+	// destination and the selected one) keep their full markers below the
+	// marker zoom, drawn above the route line. Starts matching nothing;
+	// Map.svelte sets the filter as the route and selection change
+	map.addLayer({
+		'id': 'route-stations',
+		'type': 'symbol',
+		'source': 'points',
+		'maxzoom': STATION_MARKER_MIN_ZOOM,
+		'filter': ['in', ['get', 'serialNumber'], ['literal', []]],
+		'layout': {
+			'icon-image': stationIcon('bike', 'bikes'),
+			'icon-size': ['interpolate', ['linear'], ['zoom'], 11, 0.35, STATION_MARKER_MIN_ZOOM, 0.5],
 			'icon-anchor': 'bottom',
 			'icon-allow-overlap': true,
 			'icon-padding': 0,

--- a/src/lib/map.svelte.ts
+++ b/src/lib/map.svelte.ts
@@ -123,9 +123,29 @@ export async function loadSvg(url: string, replaces?:Record<string, string>): Pr
 	});
 }
 
-/** Below this zoom stations are drawn as small dots instead of full markers,
- * so a zoomed-out map (e.g. framing a computed route) isn't buried under pins. */
-export const STATION_MARKER_MIN_ZOOM = 14;
+/** At low zoom stations are drawn as small dots instead of full markers, so a
+ * zoomed-out map (e.g. framing a computed route) isn't buried under pins.
+ * Over this zoom range the dots fade out while the pins grow in from dot size. */
+export const STATION_MARKER_FADE_START = 13.5;
+export const STATION_MARKER_FADE_END = 14;
+
+/** Dot for a station at low zoom: filled accent when it has something to
+ * offer (bikes or free docks, depending on the trip state), hollow when in
+ * service but empty, muted when out of service — matching the pins, which are
+ * only gray when out of service. */
+export function stationDotColor(countProp: 'bikes'|'freeDocks'): ExpressionSpecification {
+	return ['case',
+		['!', ['get', 'inService']], getCssVariable('--color-label'),
+		['>', ['get', countProp], 0], getCssVariable('--color-primary'),
+		getCssVariable('--color-background')];
+}
+
+export function stationDotStrokeColor(countProp: 'bikes'|'freeDocks'): ExpressionSpecification {
+	return ['case',
+		['all', ['get', 'inService'], ['<=', ['get', countProp], 0]],
+		getCssVariable('--color-primary'),
+		getCssVariable('--color-background')];
+}
 
 /** Marker for a station: a pin with the count of bikes or free docks baked in,
  * with selected/inactive variants. */
@@ -142,15 +162,6 @@ export function stationIcon(kind: 'bike'|'dock', countProp: 'bikes'|'freeDocks')
 			kind + '_inactive']];
 }
 
-/** Dot for a station at low zoom: accent when it has something to offer
- * (bikes or free docks, depending on the trip state), muted otherwise. */
-export function stationDotColor(countProp: 'bikes'|'freeDocks'): ExpressionSpecification {
-	return ['case',
-		['all', ['get', 'inService'], ['>', ['get', countProp], 0]],
-		getCssVariable('--color-primary'),
-		getCssVariable('--color-label')];
-}
-
 export function addLayers(map: maplibregl.Map) {
 	if (map.getLayer('points') != undefined) return;
 	// Added first so every later insertion before 'building' (trip path, route,
@@ -160,12 +171,14 @@ export function addLayers(map: maplibregl.Map) {
 		'id': 'station-dots',
 		'type': 'circle',
 		'source': 'points',
-		'maxzoom': STATION_MARKER_MIN_ZOOM,
+		'maxzoom': STATION_MARKER_FADE_END,
 		'paint': {
-			'circle-radius': ['interpolate', ['linear'], ['zoom'], 11, 3, STATION_MARKER_MIN_ZOOM, 5],
+			'circle-radius': ['interpolate', ['linear'], ['zoom'], 11, 3, STATION_MARKER_FADE_START, 5],
 			'circle-color': stationDotColor('bikes'),
+			'circle-opacity': ['interpolate', ['linear'], ['zoom'], STATION_MARKER_FADE_START, 1, STATION_MARKER_FADE_END, 0],
+			'circle-stroke-opacity': ['interpolate', ['linear'], ['zoom'], STATION_MARKER_FADE_START, 1, STATION_MARKER_FADE_END, 0],
 			'circle-stroke-width': 1.5,
-			'circle-stroke-color': getCssVariable('--color-background'),
+			'circle-stroke-color': stationDotStrokeColor('bikes'),
 		},
 	}, 'building');
 	map.addLayer({
@@ -260,11 +273,11 @@ export function addLayers(map: maplibregl.Map) {
 		'id': 'points',
 		'type': 'symbol',
 		'source': 'points',
-		'minzoom': STATION_MARKER_MIN_ZOOM,
+		'minzoom': STATION_MARKER_FADE_START,
 		'layout': {
 			visibility: 'visible',
 			'icon-image': stationIcon('bike', 'bikes'),
-			'icon-size': 0.5,
+			'icon-size': ['interpolate', ['linear'], ['zoom'], STATION_MARKER_FADE_START, 0.1, STATION_MARKER_FADE_END, 0.5],
 			'icon-anchor': 'bottom',
 			'icon-allow-overlap': true,
 			'icon-padding': 0,
@@ -274,29 +287,29 @@ export function addLayers(map: maplibregl.Map) {
 		'id': 'docks',
 		'type': 'symbol',
 		'source': 'points',
-		'minzoom': STATION_MARKER_MIN_ZOOM,
+		'minzoom': STATION_MARKER_FADE_START,
 		'layout': {
 			visibility: 'none',
 			'icon-image': stationIcon('dock', 'freeDocks'),
-			'icon-size': 0.5,
+			'icon-size': ['interpolate', ['linear'], ['zoom'], STATION_MARKER_FADE_START, 0.1, STATION_MARKER_FADE_END, 0.5],
 			'icon-anchor': 'bottom',
 			'icon-allow-overlap': true,
 			'icon-padding': 0,
 		},
 	});
 	// The stations that matter right now (the route's pickup/dropoff/
-	// destination and the selected one) keep their full markers below the
-	// marker zoom, drawn above the route line. Starts matching nothing;
-	// Map.svelte sets the filter as the route and selection change
+	// destination and the selected one) keep a full-size marker at every
+	// zoom, drawn above the route line — this layer covers them alone, and
+	// Map.svelte hides them from the growing regular layers. Starts matching
+	// nothing; Map.svelte sets the filter as the route and selection change
 	map.addLayer({
 		'id': 'route-stations',
 		'type': 'symbol',
 		'source': 'points',
-		'maxzoom': STATION_MARKER_MIN_ZOOM,
 		'filter': ['in', ['get', 'serialNumber'], ['literal', []]],
 		'layout': {
 			'icon-image': stationIcon('bike', 'bikes'),
-			'icon-size': ['interpolate', ['linear'], ['zoom'], 11, 0.35, STATION_MARKER_MIN_ZOOM, 0.5],
+			'icon-size': ['interpolate', ['linear'], ['zoom'], 11, 0.35, STATION_MARKER_FADE_END, 0.5],
 			'icon-anchor': 'bottom',
 			'icon-allow-overlap': true,
 			'icon-padding': 0,


### PR DESCRIPTION
Makes the map legible when zoomed out: instead of always drawing every station as a full pin, stations degrade gracefully with zoom, and the stations that matter for the current route stay prominent. Fixes the route-overview problem where fitting a computed route zoomed out and buried the route line under 150+ pins.

### Dots at low zoom (`station-dots` layer)
- Below zoom 14 stations are drawn as small dots instead of pins — the bike count baked into the pin sprite is unreadable at those sizes anyway, so the pins were pure clutter
- Dot color carries the station's state, matching the pin semantics: **filled accent** when the station has bikes (free docks during a trip), **hollow accent ring** when in service but empty, **muted gray** only when out of service
- The dot layer is inserted below the trip path and route lines, so at low zoom the route draws over the dots

### Dot-to-pin transition
- Over zoom 13.5→14 the dots fade out while the pins grow in from ~dot size (0.1× → 0.5×) at full opacity — anchored at the tip, each pin reads as sprouting out of its dot instead of the two forms popping
- Dots keep being tappable: all station layers are included in the click handlers and hit-tests

### Route/selection emphasis
- While a route is displayed, its pickup/dropoff/destination stations — plus the selected one — keep a full-size marker at **every** zoom, drawn above the route line by a dedicated `route-stations` layer (the regular layers hide them via opacity so nothing double-draws)
- Everything else dims to 40% opacity, dots and pins alike, so the fitted route overview shows the route line, its two endpoint pins, and a quiet field of dots
- All of this state (trip bike/dock counts, dimming, filters) is centralized in `applyStationDisplayState()` and re-applied on route/selection/trip changes and theme-driven style reloads

## Screenshots

| Zoomed out | Transition | Route overview | Zoomed-in route overview |
| --- | --- | --- | --- |
|<img width="300" alt="1-zoomed-out-dots" src="https://github.com/user-attachments/assets/566e27f1-b7cb-4a4c-9d85-54f1d1445d5f" />| <img width="300" alt="2-dot-to-pin-transition" src="https://github.com/user-attachments/assets/2d782bdd-364b-458f-b841-d80a4f962fd8" /> | <img width="300" alt="3-route-overview" src="https://github.com/user-attachments/assets/babbfe91-d2db-4d54-9d75-0ceffeb5560e" /> | <img width="300" alt="4-route-overview-zoomed" src="https://github.com/user-attachments/assets/357c8196-fb66-474d-a5de-db77989a183a" />|

## Test plan
- [x] `bun run check`, `bunx vitest run` (45 tests pass), eslint clean on touched files
- [x] Verified in the browser with real station data (light + dark themes, including theme switches mid-route, which reload the style)
- [x] Route overview, trip mode (dock counts), station selection, and pin-drop flows exercised
- [x] On-device testing
